### PR TITLE
Fix BindingErrorsResponse to handle null field values

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/rest/BindingErrorsResponse.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/BindingErrorsResponse.java
@@ -62,7 +62,7 @@ public class BindingErrorsResponse {
         addError(error);
     }
 
-	private List<BindingError> bindingErrors = new ArrayList<BindingError>();
+	private final List<BindingError> bindingErrors = new ArrayList<BindingError>();
 
 	public void addError(BindingError bindingError) {
 		this.bindingErrors.add(bindingError);
@@ -73,7 +73,7 @@ public class BindingErrorsResponse {
 			BindingError error = new BindingError();
 			error.setObjectName(fieldError.getObjectName());
 			error.setFieldName(fieldError.getField());
-			error.setFieldValue(fieldError.getRejectedValue().toString());
+			error.setFieldValue(String.valueOf(fieldError.getRejectedValue()));
 			error.setErrorMessage(fieldError.getDefaultMessage());
 			addError(error);
 		}
@@ -96,7 +96,7 @@ public class BindingErrorsResponse {
 		return "BindingErrorsResponse [bindingErrors=" + bindingErrors + "]";
 	}
 
-	protected class BindingError {
+	protected static class BindingError {
 
 		private String objectName;
 		private String fieldName;


### PR DESCRIPTION


### The app doesn't work properly when a required field is sent as null (the headers aren't populated)

![put-null-error](https://user-images.githubusercontent.com/11913800/94644343-67e4f780-02bf-11eb-834c-08d703392497.png)

##
##

### After the fix
![put-null-error-resolved-header](https://user-images.githubusercontent.com/11913800/94644426-a5e21b80-02bf-11eb-8678-fb8e5b898092.png)

