### PR TITLE
Fix redirecting / to Swagger UI when context path has been changed

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/rest/RootRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/RootRestController.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,9 +35,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/")
 public class RootRestController {
 
+    @Value("#{servletContext.contextPath}")
+    private String servletContextPath;
+
 	@RequestMapping(value = "/")
 	public void redirectToSwagger(HttpServletResponse response) throws IOException {
-		response.sendRedirect("/petclinic/swagger-ui.html");
+		response.sendRedirect(this.servletContextPath + "/swagger-ui.html");
 	}
 
 }


### PR DESCRIPTION
We had a problem when changing server.servlet.context-path in Spring Boot's configuration. The redirect from / to Swagger UI was no longer working. It should be relative to the current context path instead of a hardcoded value.