### PR TITLE
Bump to Spring Boot 2.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.springframework.samples</groupId>
     <artifactId>spring-petclinic-rest</artifactId>
-    <version>2.2.5</version>
+    <version>2.4.2</version>
 
     <description>REST version of the Spring Petclinic sample application</description>
     <url>https://spring-petclinic.github.io/</url>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.5.RELEASE</version>
+        <version>2.4.2</version>
         <relativePath/> <!-- lookup parent from Maven repository -->
     </parent>
 
@@ -61,6 +61,10 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
             <scope>runtime</scope>
@@ -97,6 +101,18 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/src/test/java/org/springframework/samples/petclinic/service/clinicService/ClinicServiceJdbcTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/clinicService/ClinicServiceJdbcTests.java
@@ -29,7 +29,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @SpringBootTest
 @RunWith(SpringJUnit4ClassRunner.class)
-@ActiveProfiles("jdbc, hsqldb")
+@ActiveProfiles({"jdbc", "hsqldb"})
 public class ClinicServiceJdbcTests extends AbstractClinicServiceTests {
 
 

--- a/src/test/java/org/springframework/samples/petclinic/service/clinicService/ClinicServiceJpaTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/clinicService/ClinicServiceJpaTests.java
@@ -16,7 +16,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @SpringBootTest
 @RunWith(SpringJUnit4ClassRunner.class)
-@ActiveProfiles("jpa, hsqldb")
+@ActiveProfiles({"jpa", "hsqldb"})
 public class ClinicServiceJpaTests extends AbstractClinicServiceTests {
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/service/clinicService/ClinicServiceSpringDataJpaTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/clinicService/ClinicServiceSpringDataJpaTests.java
@@ -14,7 +14,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @SpringBootTest
 @RunWith(SpringJUnit4ClassRunner.class)
-@ActiveProfiles("spring-data-jpa, hsqldb")
+@ActiveProfiles({"spring-data-jpa", "hsqldb"})
 public class ClinicServiceSpringDataJpaTests extends AbstractClinicServiceTests {
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/service/userService/UserServiceJdbcTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/userService/UserServiceJdbcTests.java
@@ -7,7 +7,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @SpringBootTest
 @RunWith(SpringJUnit4ClassRunner.class)
-@ActiveProfiles("jdbc, hsqldb")
+@ActiveProfiles({"jdbc", "hsqldb"})
 public class UserServiceJdbcTests extends AbstractUserServiceTests {
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/service/userService/UserServiceJpaTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/userService/UserServiceJpaTests.java
@@ -7,7 +7,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @SpringBootTest
 @RunWith(SpringJUnit4ClassRunner.class)
-@ActiveProfiles("jpa, hsqldb")
+@ActiveProfiles({"jpa", "hsqldb"})
 public class UserServiceJpaTests extends AbstractUserServiceTests {
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/service/userService/UserServiceSpringDataJpaTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/userService/UserServiceSpringDataJpaTests.java
@@ -7,7 +7,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @SpringBootTest
 @RunWith(SpringJUnit4ClassRunner.class)
-@ActiveProfiles("spring-data-jpa, hsqldb")
+@ActiveProfiles({"spring-data-jpa", "hsqldb"})
 public class UserServiceSpringDataJpaTests extends AbstractUserServiceTests {
 
 }


### PR DESCRIPTION
# Bump Spring Boot to version 2.4.2

## Changes related to Spring Boot 2.3.X upgrade

Beginning with Spring Boot 2.3.X-RELEASE the `spring-boot-starter-web` dependency does not depend on the validation starter anymore and hence we need to include the following dependency to use classes from `javax.validation.*`

````xml
<dependency>
  <groupId>org.springframework.boot</groupId>
  <artifactId>spring-boot-starter-validation</artifactId>
</dependency>
````

Another necessary change required with Spring Boot 2.3.X is the activation of multiple profiles with the `@ActiveProfiles` annotation. Instead of writing `@ActiveProfiles("p1,p2")` you need to write `@ActiveProfiles({"p1","p2"})`

Migration instructions:
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.3-Release-Notes#upgrading-from-spring-boot-22

## Changes related to Spring Boot 2.4.X upgrade

JUnit 5’s Vintage Engine was removed from `spring-boot-starter-test`. In order to be able to run JUnit4 tests without migrating to JUnit5 the following dependency needs to be included:

````xml
<dependency>
    <groupId>org.junit.vintage</groupId>
    <artifactId>junit-vintage-engine</artifactId>
    <scope>test</scope>
    <exclusions>
        <exclusion>
            <groupId>org.hamcrest</groupId>
            <artifactId>hamcrest-core</artifactId>
        </exclusion>
    </exclusions>
</dependency>
````

Migration instructions:
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.4-Release-Notes#upgrading-from-spring-boot-23