### PR TITLE
Replace deprecated property 'spring.datasource.initialize'

### DIFF
--- a/src/main/resources/application-mysql.properties
+++ b/src/main/resources/application-mysql.properties
@@ -1,5 +1,5 @@
 # uncomment for init database (first start)
-#spring.datasource.initialize=true
+#spring.datasource.initialization-mode=always
 #spring.datasource.schema=classpath*:db/mysql/initDB.sql
 #spring.datasource.data=classpath*:db/mysql/populateDB.sql
 

--- a/src/main/resources/application-postgresql.properties
+++ b/src/main/resources/application-postgresql.properties
@@ -1,5 +1,5 @@
 # uncomment for init database (first start)
-#spring.datasource.initialize=true
+#spring.datasource.initialization-mode=always
 #spring.datasource.schema=classpath*:db/postgresql/initDB.sql
 #spring.datasource.data=classpath*:db/postgresql/populateDB.sql
 


### PR DESCRIPTION
I've replaced the deprecated 'spring.datasource.initialize' with the recommended 'spring.datasource.initialization-mode' property. 

> Database Initialization
> Basic DataSource initialization is now only enabled for embedded data sources and will switch off as soon as you’re using a production database. The new `spring.datasource.initialization-mode` (replacing `spring.datasource.initialize`) offers more 
 control.

See: 
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Migration-Guide
https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-database-initialization
