### PR TITLE
Remove jcenter repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,15 +26,6 @@
         <docker.image.prefix>springcommunity</docker.image.prefix>
     </properties>
 
-    <!-- repository for springfox plugin -->
-    <repositories>
-        <repository>
-            <id>jcenter-snapshots</id>
-            <name>jcenter</name>
-            <url>https://jcenter.bintray.com/</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
JFrog has announced that they are [sunsetting jcenter](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)

Springfox is [also in maven](https://repo1.maven.org/maven2/io/springfox/)...so I don't think this is needed.  It ran fine without for me.

