### PR TITLE
Add spring actuator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,10 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
         </dependency>
         <dependency>

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,10 @@ docker run -p 9966:9966 springcommunity/spring-petclinic-rest
 
 You can then access petclinic here: [http://localhost:9966/petclinic/](http://localhost:9966/petclinic/)
 
+There are actuator health check and info routes as well: 
+* [http://localhost:9966/petclinic/actuator/health](http://localhost:9966/petclinic/actuator/health)
+* [http://localhost:9966/petclinic/actuator/info](http://localhost:9966/petclinic/actuator/info)
+
 ## Swagger REST API documentation presented here (after application start):
 [http://localhost:9966/petclinic/swagger-ui.html](http://localhost:9966/petclinic/swagger-ui.html)
 


### PR DESCRIPTION
This adds `spring-boot-starter-actuator` in order to provide health check and info routes. 

Because `spring-petclinic-rest` is often used as a basic, representative test application, it is often helpful to have a health check to assist in automated deployment environments.  Having a real health check route is preferred over just looking for 200 on a different REST endpoint or checking the swagger UI.  Actuator fits the bill smoothly here!

I also made a note in the README about the two new helpful endpoints.