### PR TITLE
APPLICATION_JSON_UTF8_VALUE is Deprecated

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/rest/PetTypeRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/PetTypeRestController.java
@@ -46,7 +46,7 @@ public class PetTypeRestController {
 	@Autowired
 	private ClinicService clinicService;
 	
-	@RequestMapping(value = "", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	@RequestMapping(value = "", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Collection<PetType>> getAllPetTypes(){
 		Collection<PetType> petTypes = new ArrayList<PetType>();
 		petTypes.addAll(this.clinicService.findAllPetTypes());
@@ -56,7 +56,7 @@ public class PetTypeRestController {
 		return new ResponseEntity<Collection<PetType>>(petTypes, HttpStatus.OK);
 	}
 	
-	@RequestMapping(value = "/{petTypeId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	@RequestMapping(value = "/{petTypeId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<PetType> getPetType(@PathVariable("petTypeId") int petTypeId){
 		PetType petType = this.clinicService.findPetTypeById(petTypeId);
 		if(petType == null){
@@ -66,7 +66,7 @@ public class PetTypeRestController {
 	}
 	
 	
-	@RequestMapping(value = "", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	@RequestMapping(value = "", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<PetType> addPetType(@RequestBody @Valid PetType petType, BindingResult bindingResult, UriComponentsBuilder ucBuilder){
 		BindingErrorsResponse errors = new BindingErrorsResponse();
 		HttpHeaders headers = new HttpHeaders();
@@ -80,7 +80,7 @@ public class PetTypeRestController {
 		return new ResponseEntity<PetType>(petType, headers, HttpStatus.CREATED);
 	}
 	
-	@RequestMapping(value = "/{petTypeId}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	@RequestMapping(value = "/{petTypeId}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<PetType> updatePetType(@PathVariable("petTypeId") int petTypeId, @RequestBody @Valid PetType petType, BindingResult bindingResult){
 		BindingErrorsResponse errors = new BindingErrorsResponse();
 		HttpHeaders headers = new HttpHeaders();
@@ -98,7 +98,7 @@ public class PetTypeRestController {
 		return new ResponseEntity<PetType>(currentPetType, HttpStatus.NO_CONTENT);
 	}
 	
-	@RequestMapping(value = "/{petTypeId}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	@RequestMapping(value = "/{petTypeId}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional
 	public ResponseEntity<Void> deletePetType(@PathVariable("petTypeId") int petTypeId){
 		PetType petType = this.clinicService.findPetTypeById(petTypeId);


### PR DESCRIPTION
From Documentation:

"APPLICATION_JSON_UTF8_VALUE
Deprecated. as of 5.2 in favor of APPLICATION_JSON_VALUE since major browsers like Chrome now comply with the specification and interpret correctly UTF-8 special characters without requiring a charset=UTF-8 parameter"

https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/MediaType.html