### PR TITLE
ignoring unnecessarily generated jacoco report

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -20,4 +20,4 @@ jobs:
           distribution: 'adopt'
           cache: maven
       - name: Build with Maven
-        run: mvn -B install --file pom.xml
+        run: mvn -B install --file pom.xml -Djacoco.skip=true


### PR DESCRIPTION
In our analysis, we observe that the target/site/ directory is generated but not later used during the CI build. Hence, we propose to disable generating this directory to save runtime. The generation of this directory can be disabled by simply adding -Djacoco.skip=true to the mvn command.

