### PR TITLE
ignoring unnecessarily generated surefire report

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -20,4 +20,4 @@ jobs:
           distribution: 'adopt'
           cache: maven
       - name: Build with Maven
-        run: mvn -B install --file pom.xml -Djacoco.skip=true
+        run: mvn -B install --file pom.xml -Djacoco.skip=true -DdisableXmlReport=true


### PR DESCRIPTION
In our analysis, we observe that this target/surefire-report/ directory is generated but not later used during the CI build. Hence, we propose to disable generating this directory to save runtime.
The generation of this directory can be disabled by simply adding -DdisableXmlReport=true to the mvn command.