### PR TITLE
Fix "Create PetType endpoint returns wrong PetType ID" 

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/PetTypeRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/PetTypeRestController.java
@@ -29,8 +29,10 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import jakarta.transaction.Transactional;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @RestController
 @CrossOrigin(exposedHeaders = "errors, content-type")
@@ -70,10 +72,14 @@ public class PetTypeRestController implements PettypesApi {
     @Override
     public ResponseEntity<PetTypeDto> addPetType(PetTypeDto petTypeDto) {
         HttpHeaders headers = new HttpHeaders();
-        final PetType type = petTypeMapper.toPetType(petTypeDto);
-        this.clinicService.savePetType(type);
-        headers.setLocation(UriComponentsBuilder.newInstance().path("/api/pettypes/{id}").buildAndExpand(type.getId()).toUri());
-        return new ResponseEntity<>(petTypeMapper.toPetTypeDto(type), headers, HttpStatus.CREATED);
+        if (Objects.nonNull(petTypeDto.getId()) && !petTypeDto.getId().equals(0)) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        } else {
+            final PetType type = petTypeMapper.toPetType(petTypeDto);
+            this.clinicService.savePetType(type);
+            headers.setLocation(UriComponentsBuilder.newInstance().path("/api/pettypes/{id}").buildAndExpand(type.getId()).toUri());
+            return new ResponseEntity<>(petTypeMapper.toPetTypeDto(type), headers, HttpStatus.CREATED);
+        }
     }
 
     @PreAuthorize("hasRole(@roles.VET_ADMIN)")

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/PetTypeRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/PetTypeRestControllerTests.java
@@ -27,6 +27,7 @@ import org.springframework.samples.petclinic.mapper.PetTypeMapper;
 import org.springframework.samples.petclinic.model.PetType;
 import org.springframework.samples.petclinic.rest.advice.ExceptionControllerAdvice;
 import org.springframework.samples.petclinic.rest.controller.PetTypeRestController;
+import org.springframework.samples.petclinic.rest.dto.PetTypeDto;
 import org.springframework.samples.petclinic.service.ClinicService;
 import org.springframework.samples.petclinic.service.clinicService.ApplicationTestConfig;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -173,7 +174,7 @@ class PetTypeRestControllerTests {
     @WithMockUser(roles="VET_ADMIN")
     void testCreatePetTypeSuccess() throws Exception {
     	PetType newPetType = petTypes.get(0);
-    	newPetType.setId(999);
+    	newPetType.setId(null);
     	ObjectMapper mapper = new ObjectMapper();
         String newPetTypeAsJSON = mapper.writeValueAsString(petTypeMapper.toPetTypeDto(newPetType));
     	this.mockMvc.perform(post("/api/pettypes/")
@@ -193,7 +194,17 @@ class PetTypeRestControllerTests {
         		.content(newPetTypeAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
         		.andExpect(status().isBadRequest());
      }
-
+    @Test
+    @WithMockUser(roles="VET_ADMIN")
+    void testCreatePetTypeErrorWithId() throws Exception {
+        PetType newPetType = petTypes.get(0);
+        newPetType.setId(1);
+        ObjectMapper mapper = new ObjectMapper();
+        String newPetTypeAsJSON = mapper.writeValueAsString(petTypeMapper.toPetTypeDto(newPetType));
+        this.mockMvc.perform(post("/api/pettypes/")
+                .content(newPetTypeAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest());
+    }
     @Test
     @WithMockUser(roles="VET_ADMIN")
     void testUpdatePetTypeSuccess() throws Exception {


### PR DESCRIPTION
## Purpose

Checks the presence of an id in the incoming resquest of POST /pettypes. If so, an HTTP 400 error is thrown.

Fix #88
Close #88

## How is it done?
By adding a custom validation in the method addPetType()

## Validation
An additional test has been implemented : testCreatePetTypeErrorWithId()
