### PR TITLE
Build & publish Docker image using GitHub Workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,28 @@
+---
+name: Build to Docker Hub
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build & publish the project
+        run: mvn compile jib:build -X -DjibSerialize=true

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: maven
       - name: Build with Maven
         run: mvn -B install --file pom.xml -Djacoco.skip=true -DdisableXmlReport=true

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     </parent>
 
     <properties>
-        <!-- Third librairies -->
+        <!-- Third-party libraries -->
         <spring-data-jdbc.version>1.2.1.RELEASE</spring-data-jdbc.version>
         <springdoc-openapi-ui.version>2.0.2</springdoc-openapi-ui.version>
         <jackson-databind-nullable.version>0.2.1</jackson-databind-nullable.version>
@@ -31,7 +31,7 @@
         <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
 
         <!-- Docker -->
-        <docker.jib-maven-plugin.version>1.3.0</docker.jib-maven-plugin.version>
+        <docker.jib-maven-plugin.version>3.4.0</docker.jib-maven-plugin.version>
         <docker.image.prefix>springcommunity</docker.image.prefix>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     </properties>

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 # REST version of Spring PetClinic Sample Application (spring-framework-petclinic extend ) 
 
-[![Build Status](https://github.com/spring-petclinic/spring-petclinic-rest/actions/workflows/maven-build.yml/badge.svg)](https://github.com/spring-petclinic/spring-petclinic-rest/actions/workflows/maven-build.yml)
+[![Java Build Status](https://github.com/spring-petclinic/spring-petclinic-rest/actions/workflows/maven-build.yml/badge.svg)](https://github.com/spring-petclinic/spring-petclinic-rest/actions/workflows/maven-build.yml)
+[![Docker Build Status](https://github.com/spring-petclinic/spring-petclinic-rest/actions/workflows/docker-build.yml/badge.svg)](https://github.com/spring-petclinic/spring-petclinic-rest/actions/workflows/docker-build.yml)
 
 This backend version of the Spring Petclinic application only provides a REST API. **There is no UI**.
 The [spring-petclinic-angular project](https://github.com/spring-petclinic/spring-petclinic-angular) is a Angular front-end application which consumes the REST API.


### PR DESCRIPTION
Good day!

I created a new workflow to automate building Docker image and publishing it to Docker Hub.
It is also to resolve issue #93, as I noticed the images on Docker Hub are outdated.

I have tested the new workflow in a separate branch during development.
The successful workflow run log can be found at: https://github.com/addianto/spring-petclinic-rest/actions/runs/6611300030/job/17954895176

Please note that the workflow requires two GitHub Secrets (i.e., `DOCKERHUB_USERNAME` & `DOCKERHUB_TOKEN`).
I assume the project's maintainers do have access to the Docker Hub account that publishes the image in order to create the required GitHub Secrets.