### PR TITLE
Added findByPetTypeByName and findSpecialtiesByName, caching responses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,11 @@
         <jackson-databind-nullable.version>0.2.1</jackson-databind-nullable.version>
         <mapstruct.version>1.4.1.Final</mapstruct.version>
         <jaxb-api.version>2.3.0</jaxb-api.version>
-
+        <caffeine.version>3.1.8</caffeine.version>
         <!-- Maven plugins -->
         <jacoco.version>0.8.8</jacoco.version>
         <openapi-generator-maven-plugin.version>6.3.0</openapi-generator-maven-plugin.version>
         <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
-
         <!-- Docker -->
         <docker.jib-maven-plugin.version>3.4.0</docker.jib-maven-plugin.version>
         <docker.image.prefix>springcommunity</docker.image.prefix>
@@ -44,6 +43,10 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -84,6 +87,15 @@
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>${caffeine.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.data</groupId>
@@ -96,7 +108,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/java/org/springframework/samples/petclinic/PetClinicApplication.java
+++ b/src/main/java/org/springframework/samples/petclinic/PetClinicApplication.java
@@ -4,7 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.springframework.cache.annotation.EnableCaching;
 
+@EnableCaching
 @SpringBootApplication
 public class PetClinicApplication extends SpringBootServletInitializer {
 

--- a/src/main/java/org/springframework/samples/petclinic/config/CacheConfig.java
+++ b/src/main/java/org/springframework/samples/petclinic/config/CacheConfig.java
@@ -1,0 +1,25 @@
+package org.springframework.samples.petclinic.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class CacheConfig {
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+        cacheManager.setCaffeine(
+            Caffeine.newBuilder()
+                .expireAfterAccess(10, TimeUnit.MINUTES)
+                .recordStats()
+                .maximumSize(500)
+        );
+        return cacheManager;
+    }
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/PetTypeRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/PetTypeRepository.java
@@ -27,13 +27,15 @@ import org.springframework.samples.petclinic.model.PetType;
  */
 
 public interface PetTypeRepository {
-	
+
 	PetType findById(int id) throws DataAccessException;
-	
+
+    PetType findByName(String name) throws DataAccessException;
+
 	Collection<PetType> findAll() throws DataAccessException;
 
 	void save(PetType petType) throws DataAccessException;
-	
+
 	void delete(PetType petType) throws DataAccessException;
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/SpecialtyRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/SpecialtyRepository.java
@@ -17,6 +17,8 @@
 package org.springframework.samples.petclinic.repository;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.samples.petclinic.model.Specialty;
@@ -27,13 +29,15 @@ import org.springframework.samples.petclinic.model.Specialty;
  */
 
 public interface SpecialtyRepository {
-	
+
 	Specialty findById(int id) throws DataAccessException;
-	
-	Collection<Specialty> findAll() throws DataAccessException;
-	
+
+    List<Specialty> findByNameIn(Set<String> names);
+
+    Collection<Specialty> findAll() throws DataAccessException;
+
 	void save(Specialty specialty) throws DataAccessException;
-	
+
 	void delete(Specialty specialty) throws DataAccessException;
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/VetRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/VetRepository.java
@@ -38,11 +38,11 @@ public interface VetRepository {
      * @return a <code>Collection</code> of <code>Vet</code>s
      */
     Collection<Vet> findAll() throws DataAccessException;
-    
+
 	Vet findById(int id) throws DataAccessException;
 
 	void save(Vet vet) throws DataAccessException;
-	
+
 	void delete(Vet vet) throws DataAccessException;
 
 

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetTypeRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetTypeRepositoryImpl.java
@@ -47,11 +47,11 @@ import org.springframework.stereotype.Repository;
 @Repository
 @Profile("jdbc")
 public class JdbcPetTypeRepositoryImpl implements PetTypeRepository {
-	
+
 	private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
-	
+
 	private SimpleJdbcInsert insertPetType;
-	
+
 	@Autowired
 	public JdbcPetTypeRepositoryImpl(DataSource dataSource) {
 		this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
@@ -76,7 +76,23 @@ public class JdbcPetTypeRepositoryImpl implements PetTypeRepository {
         return petType;
 	}
 
-	@Override
+    @Override
+    public PetType findByName(String name) throws DataAccessException {
+        PetType petType;
+        try {
+            Map<String, Object> params = new HashMap<>();
+            params.put("name", name);
+            petType = this.namedParameterJdbcTemplate.queryForObject(
+                "SELECT id, name FROM types WHERE name= :name",
+                params,
+                BeanPropertyRowMapper.newInstance(PetType.class));
+        } catch (EmptyResultDataAccessException ex) {
+            throw new ObjectRetrievalFailureException(PetType.class, name);
+        }
+        return petType;
+    }
+
+    @Override
 	public Collection<PetType> findAll() throws DataAccessException {
 		Map<String, Object> params = new HashMap<>();
         return this.namedParameterJdbcTemplate.query(

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetTypeRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetTypeRepositoryImpl.java
@@ -48,7 +48,15 @@ public class JpaPetTypeRepositoryImpl implements PetTypeRepository {
 		return this.em.find(PetType.class, id);
 	}
 
-	@SuppressWarnings("unchecked")
+    @Override
+    public PetType findByName(String name) throws DataAccessException {
+        return this.em.createQuery("SELECT p FROM PetType p WHERE p.name = :name", PetType.class)
+            .setParameter("name", name)
+            .getSingleResult();
+    }
+
+
+    @SuppressWarnings("unchecked")
 	@Override
 	public Collection<PetType> findAll() throws DataAccessException {
 		return this.em.createQuery("SELECT ptype FROM PetType ptype").getResultList();

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaSpecialtyRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaSpecialtyRepositoryImpl.java
@@ -17,6 +17,8 @@
 package org.springframework.samples.petclinic.repository.jpa;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -44,7 +46,16 @@ public class JpaSpecialtyRepositoryImpl implements SpecialtyRepository {
 		return this.em.find(Specialty.class, id);
 	}
 
-	@SuppressWarnings("unchecked")
+    @Override
+    public List<Specialty> findByNameIn(Set<String> names) {
+        final String jpql = "SELECT s FROM Specialty s WHERE s.name IN :names";
+        List<Specialty> specialties = em.createQuery(jpql, Specialty.class)
+            .setParameter("names", names)
+            .getResultList();
+        return specialties;
+    }
+
+    @SuppressWarnings("unchecked")
 	@Override
 	public Collection<Specialty> findAll() throws DataAccessException {
 		return this.em.createQuery("SELECT s FROM Specialty s").getResultList();

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
@@ -24,6 +24,7 @@ import org.springframework.samples.petclinic.mapper.PetMapper;
 import org.springframework.samples.petclinic.mapper.VisitMapper;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.model.Pet;
+import org.springframework.samples.petclinic.model.PetType;
 import org.springframework.samples.petclinic.model.Visit;
 import org.springframework.samples.petclinic.rest.api.OwnersApi;
 import org.springframework.samples.petclinic.rest.dto.*;
@@ -38,7 +39,6 @@ import jakarta.transaction.Transactional;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * @author Vitaliy Fedoriv
@@ -140,6 +140,8 @@ public class OwnerRestController implements OwnersApi {
         Owner owner = new Owner();
         owner.setId(ownerId);
         pet.setOwner(owner);
+        PetType petType = this.clinicService.findPetTypeByName(pet.getType().getName());
+        pet.setType(petType);
         this.clinicService.savePet(pet);
         PetDto petDto = petMapper.toPetDto(pet);
         headers.setLocation(UriComponentsBuilder.newInstance().path("/api/pets/{id}")

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/VetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/VetRestController.java
@@ -22,6 +22,7 @@ import org.springframework.samples.petclinic.mapper.SpecialtyMapper;
 import org.springframework.samples.petclinic.mapper.VetMapper;
 import org.springframework.samples.petclinic.model.Specialty;
 import org.springframework.samples.petclinic.model.Vet;
+import org.springframework.samples.petclinic.repository.VetRepository;
 import org.springframework.samples.petclinic.rest.api.VetsApi;
 import org.springframework.samples.petclinic.rest.dto.VetDto;
 import org.springframework.samples.petclinic.service.ClinicService;
@@ -31,7 +32,10 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Vitaliy Fedoriv
@@ -78,6 +82,10 @@ public class VetRestController implements VetsApi {
     public ResponseEntity<VetDto> addVet(VetDto vetDto) {
         HttpHeaders headers = new HttpHeaders();
         Vet vet = vetMapper.toVet(vetDto);
+        if(vet.getNrOfSpecialties() > 0){
+            List<Specialty> vetSpecialities = this.clinicService.findSpecialtiesByName(vet.getSpecialties().stream().map(Specialty::getName).collect(Collectors.toSet()));
+            vet.setSpecialties(vetSpecialities);
+        }
         this.clinicService.saveVet(vet);
         headers.setLocation(UriComponentsBuilder.newInstance().path("/api/vets/{id}").buildAndExpand(vet.getId()).toUri());
         return new ResponseEntity<>(vetMapper.toVetDto(vet), headers, HttpStatus.CREATED);
@@ -95,6 +103,10 @@ public class VetRestController implements VetsApi {
         currentVet.clearSpecialties();
         for (Specialty spec : specialtyMapper.toSpecialtys(vetDto.getSpecialties())) {
             currentVet.addSpecialty(spec);
+        }
+        if(currentVet.getNrOfSpecialties() > 0){
+            List<Specialty> vetSpecialities = this.clinicService.findSpecialtiesByName(currentVet.getSpecialties().stream().map(Specialty::getName).collect(Collectors.toSet()));
+            currentVet.setSpecialties(vetSpecialities);
         }
         this.clinicService.saveVet(currentVet);
         return new ResponseEntity<>(vetMapper.toVetDto(currentVet), HttpStatus.NO_CONTENT);

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicService.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicService.java
@@ -16,6 +16,8 @@
 package org.springframework.samples.petclinic.service;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.samples.petclinic.model.Owner;
@@ -24,7 +26,6 @@ import org.springframework.samples.petclinic.model.PetType;
 import org.springframework.samples.petclinic.model.Specialty;
 import org.springframework.samples.petclinic.model.Vet;
 import org.springframework.samples.petclinic.model.Visit;
-
 
 /**
  * Mostly used as a facade so all controllers have a single point of entry
@@ -44,13 +45,11 @@ public interface ClinicService {
 	Collection<Visit> findAllVisits() throws DataAccessException;
 	void saveVisit(Visit visit) throws DataAccessException;
 	void deleteVisit(Visit visit) throws DataAccessException;
-	
 	Vet findVetById(int id) throws DataAccessException;
 	Collection<Vet> findVets() throws DataAccessException;
 	Collection<Vet> findAllVets() throws DataAccessException;
 	void saveVet(Vet vet) throws DataAccessException;
 	void deleteVet(Vet vet) throws DataAccessException;
-	
 	Owner findOwnerById(int id) throws DataAccessException;
 	Collection<Owner> findAllOwners() throws DataAccessException;
 	void saveOwner(Owner owner) throws DataAccessException;
@@ -62,10 +61,12 @@ public interface ClinicService {
 	Collection<PetType> findPetTypes() throws DataAccessException;
 	void savePetType(PetType petType) throws DataAccessException;
 	void deletePetType(PetType petType) throws DataAccessException;
-	
 	Specialty findSpecialtyById(int specialtyId);
 	Collection<Specialty> findAllSpecialties() throws DataAccessException;
 	void saveSpecialty(Specialty specialty) throws DataAccessException;
 	void deleteSpecialty(Specialty specialty) throws DataAccessException;
 
+    List<Specialty> findSpecialtiesByName(Set<String> names) throws DataAccessException;
+
+    PetType findPetTypeByName(String name) throws DataAccessException;
 }

--- a/src/test/java/org/springframework/samples/petclinic/service/clinicService/AbstractClinicServiceTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/clinicService/AbstractClinicServiceTests.java
@@ -25,8 +25,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.setMaxStackTraceElementsDisplayed;
 
 /**
  * <p> Base class for {@link ClinicService} integration tests. </p> <p> Subclasses should specify Spring context
@@ -469,6 +473,34 @@ abstract class AbstractClinicServiceTests {
 		}
         assertThat(specialty).isNull();
     }
+
+    @Test
+    @Transactional
+    void shouldFindSpecialtyByName() {
+        Specialty specialty1 = new Specialty();
+        specialty1.setName("radiology");
+        specialty1.setId(1);
+        Specialty specialty2 = new Specialty();
+        specialty2.setName("surgery");
+        specialty2.setId(2);
+        Specialty specialty3 = new Specialty();
+        specialty3.setName("dentistry");
+        specialty3.setId(3);
+        List<Specialty> expectedSpecialties = List.of(specialty1, specialty2, specialty3);
+        Set<String> specialtyNames = expectedSpecialties.stream()
+            .map(Specialty::getName)
+            .collect(Collectors.toSet());
+        Collection<Specialty> actualSpecialties = this.clinicService.findSpecialtiesByName(specialtyNames);
+        assertThat(actualSpecialties).isNotNull();
+        assertThat(actualSpecialties.size()).isEqualTo(expectedSpecialties.size());
+        for (Specialty expected : expectedSpecialties) {
+            assertThat(actualSpecialties.stream()
+                .anyMatch(
+                    actual -> actual.getName().equals(expected.getName())
+                    && actual.getId().equals(expected.getId()))).isTrue();
+        }
+    }
+
 
 
 }


### PR DESCRIPTION
### Purpose
-----------------------------
These changes aim to fix issues #122  #103 while maintaining API first approach. 
#### What and Why
-----------------------------
##### Key changes

- Added findByPetTypeByName
- Added findSpecialtiesByName
- Added caching logic

I've taken an oppinioned approach, I'm requesting specialties/pettypes by name in order to retrieve their IDs and thus ignoring the "id" in **PetTypeDTO** and **SpecialtyDTO**, however I've not made any changes to the DTO as to not break clients. 

**PetTypes** and **Specialties** seem like good data to cache as frequent changes to the specialties/pettypes are not expected, so I've also added caching logic in order to reduce load on the database, as this solution naturally puts more load onto it. 
### Validation
------------------------------------
Already existing integration tests and created additional ones for finding pettype and specialties
_I apologise for the large commit, will split if needed/fix any issues with code quality_ 