### PR TITLE
Caching returns of findPetTypeByName and findSpecialtiesByNameIn

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <jackson-databind-nullable.version>0.2.1</jackson-databind-nullable.version>
         <mapstruct.version>1.4.1.Final</mapstruct.version>
         <jaxb-api.version>2.3.0</jaxb-api.version>
+        <caffeine.version>3.1.8</caffeine.version>
 
         <!-- Maven plugins -->
         <jacoco.version>0.8.8</jacoco.version>
@@ -158,6 +159,13 @@
             <artifactId>jaxb-api</artifactId>
             <version>${jaxb-api.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>${caffeine.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/org/springframework/samples/petclinic/config/CacheConfig.java
+++ b/src/main/java/org/springframework/samples/petclinic/config/CacheConfig.java
@@ -1,0 +1,31 @@
+package org.springframework.samples.petclinic.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+    @Value("${cache.expiration.minutes}")
+    private int cacheExpirationMinutes;
+
+    @Value("${cache.maximum.size}")
+    private int cacheMaximumSize;
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+        cacheManager.setCaffeine(
+            Caffeine.newBuilder()
+                .expireAfterAccess(cacheExpirationMinutes, TimeUnit.MINUTES)
+                .maximumSize(cacheMaximumSize)
+        );
+        return cacheManager;
+    }
+}

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.orm.ObjectRetrievalFailureException;
@@ -179,6 +181,7 @@ public class ClinicServiceImpl implements ClinicService {
 
 	@Override
 	@Transactional
+    @CacheEvict(value = "petTypes", key = "#petType.name")
 	public void deletePetType(PetType petType) throws DataAccessException {
 		petTypeRepository.delete(petType);
 	}
@@ -210,6 +213,7 @@ public class ClinicServiceImpl implements ClinicService {
 
 	@Override
 	@Transactional
+    @CacheEvict(value = "specialties", allEntries = true)
 	public void deleteSpecialty(Specialty specialty) throws DataAccessException {
 		specialtyRepository.delete(specialty);
 	}
@@ -286,6 +290,7 @@ public class ClinicServiceImpl implements ClinicService {
 
     @Override
     @Transactional(readOnly = true)
+    @Cacheable(value = "specialties", key = "#names")
     public List<Specialty> findSpecialtiesByNameIn(Set<String> names){
         List<Specialty> specialties = new ArrayList<>();
         try {
@@ -299,6 +304,7 @@ public class ClinicServiceImpl implements ClinicService {
 
     @Override
     @Transactional(readOnly = true)
+    @Cacheable(value = "petTypes", key = "#name")
     public PetType findPetTypeByName(String name){
         PetType petType;
         try {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,3 +36,5 @@ logging.level.org.springframework=INFO
 # by default the authentication is disabled
 petclinic.security.enable=false
 
+cache.expiration.minutes=10
+cache.maximum.size=500

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -37,3 +37,5 @@ security.ignored=/**
 basic.authentication.enabled=true
 petclinic.security.enable=true
 
+cache.expiration.minutes=10
+cache.maximum.size=500


### PR DESCRIPTION
Adding logic for caching returns of findSpecialtiesByNameIn and findPetTypeByName
 Purpose

PR  #124   is a "hacky fix" and puts additional load on the DB in order to mimize that, I've implemented a cache. 
related to: #123 