### PR TITLE
Upgrade Spring Boot to 3.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.springframework.samples</groupId>
     <artifactId>spring-petclinic-rest</artifactId>
-    <version>3.0.2</version>
+    <version>3.2.1</version>
 
     <description>REST version of the Spring Petclinic sample application</description>
     <url>https://spring-petclinic.github.io/</url>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.2.1</version>
         <relativePath/> <!-- lookup parent from Maven repository -->
     </parent>
 
@@ -75,8 +75,8 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -176,8 +176,7 @@
                             <additionalProperties>
                                 <encoding.source>${project.build.sourceEncoding}</encoding.source>
                                 <encoding.reporting>${project.reporting.outputEncoding}</encoding.reporting>
-                                <java.source>${maven.compiler.source}</java.source>
-                                <java.target>${maven.compiler.target}</java.target>
+                                <java.release>${maven.compiler.release}</java.release>
                             </additionalProperties>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Upgrade dependencies to Spring Boot 3.2.1 (and transitively Spring 6.1.2) to make it possible to experiment with Spring's new [Checkpoint/Restore](https://docs.spring.io/spring-framework/reference/integration/checkpoint-restore.html) and [Virtual Threads](https://spring.io/blog/2023/09/09/all-together-now-spring-boot-3-2-graalvm-native-images-java-21-and-virtual/#configuring-a-spring-boot-project-to-use-java-21) support. 