### PR TITLE
Upgrade jacoco to 0.8.11 such that we can build with JDK 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <jaxb-api.version>2.3.0</jaxb-api.version>
 
         <!-- Maven plugins -->
-        <jacoco.version>0.8.8</jacoco.version>
+        <jacoco.version>0.8.11</jacoco.version>
         <openapi-generator-maven-plugin.version>6.3.0</openapi-generator-maven-plugin.version>
         <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
 


### PR DESCRIPTION
Notice that building with JDK 17 and running with JDK 21 (including virtual threads support) works just fine, as long as we don't use virtual threads in our application because the Spring framework is packaged as a multi-release jar file. We only need to build with JDK 21 if we want to use 21 features in our application.

The jacoco upgrade is needed because jacoco tries to instrument some of the JDK classes and the current version 0.8.8 doesn't understand the JDK 21 classs if we are building with JDK 21.