### PR TITLE
fix: security configuration updated for 6.3.x version

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/security/BasicAuthenticationConfig.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/BasicAuthenticationConfig.java
@@ -1,23 +1,22 @@
 package org.springframework.samples.petclinic.security;
 
-import javax.sql.DataSource;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.crypto.factory.PasswordEncoderFactories;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 
+import javax.sql.DataSource;
+
 @Configuration
-@EnableGlobalMethodSecurity(prePostEnabled = true) // Enable @PreAuthorize method-level security
+@EnableMethodSecurity(prePostEnabled = true) // Enable @PreAuthorize method-level security
 @ConditionalOnProperty(name = "petclinic.security.enable", havingValue = "true")
-public class BasicAuthenticationConfig  {
+public class BasicAuthenticationConfig {
 
     @Autowired
     private DataSource dataSource;
@@ -26,13 +25,10 @@ public class BasicAuthenticationConfig  {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         // @formatter:off
         http
+            .csrf(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests((authz) -> authz
-                .anyRequest().authenticated()
-                )
-                .httpBasic()
-                    .and()
-                .csrf()
-                    .disable();
+                .anyRequest().authenticated())
+                .httpBasic(Customizer.withDefaults());
         // @formatter:on
         return http.build();
     }

--- a/src/main/java/org/springframework/samples/petclinic/security/DisableSecurityConfig.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/DisableSecurityConfig.java
@@ -4,6 +4,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 
 /**
@@ -18,11 +19,10 @@ public class DisableSecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         // @formatter:off
         http
+            .csrf(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests((authz) -> authz
                .anyRequest().permitAll()
-            )
-            .csrf()
-                .disable();
+            );
         // @formatter:on
         return http.build();
     }


### PR DESCRIPTION
Whereas some methods of SecurityFilterChain have been marked for the removal or deprecated, they're need to be updated