### PR TITLE
fix: correct 404 responses and refactor error information to use record

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/rest/advice/ExceptionControllerAdvice.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/advice/ExceptionControllerAdvice.java
@@ -18,6 +18,7 @@ package org.springframework.samples.petclinic.rest.advice;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -33,23 +34,41 @@ import org.springframework.web.context.request.WebRequest;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 /**
+ * Global Exception handler for REST controllers.
+ * <p>
+ * This class handles exceptions thrown by REST controllers and returns
+ * appropriate HTTP responses to the client.
+ *
  * @author Vitaliy Fedoriv
+ * @author Alexander Dudkin
  */
-
 @ControllerAdvice
 public class ExceptionControllerAdvice {
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<String> exception(Exception e) {
-        ObjectMapper mapper = new ObjectMapper();
-        ErrorInfo errorInfo = new ErrorInfo(e);
-        String respJSONstring = "{}";
-        try {
-            respJSONstring = mapper.writeValueAsString(errorInfo);
-        } catch (JsonProcessingException e1) {
-            e1.printStackTrace();
+    /**
+     * Record for storing error information.
+     * <p>
+     * This record encapsulates the class name and message of the exception.
+     *
+     * @param className The name of the exception class
+     * @param exMessage The message of the exception
+     */
+    private record ErrorInfo(String className, String exMessage) {
+        public ErrorInfo(Exception ex) {
+            this(ex.getClass().getName(), ex.getLocalizedMessage());
         }
-        return ResponseEntity.badRequest().body(respJSONstring);
+    }
+
+    /**
+     * Handles all general exceptions by returning a 500 Internal Server Error status with error details.
+     *
+     * @param  e The exception to be handled
+     * @return A {@link ResponseEntity} containing the error information and a 500 Internal Server Error status
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorInfo> handleGeneralException(Exception e) {
+        ErrorInfo info = new ErrorInfo(e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(info);
     }
 
     /**
@@ -73,13 +92,19 @@ public class ExceptionControllerAdvice {
         return new ResponseEntity<>(headers, HttpStatus.BAD_REQUEST);
     }
 
-    private class ErrorInfo {
-        public final String className;
-        public final String exMessage;
-
-        public ErrorInfo(Exception ex) {
-            this.className = ex.getClass().getName();
-            this.exMessage = ex.getLocalizedMessage();
-        }
+    /**
+     * Handles {@link DataIntegrityViolationException} which typically indicates database constraint violations.
+     * This method returns a 404 Not Found status if an entity does not exist.
+     *
+     * @param ex The {@link DataIntegrityViolationException} to be handled
+     * @return A {@link ResponseEntity} containing the error information and a 404 Not Found status
+     */
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    @ResponseStatus(code = HttpStatus.NOT_FOUND)
+    @ResponseBody
+    public ResponseEntity<ErrorInfo> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
+        ErrorInfo errorInfo = new ErrorInfo(ex);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorInfo);
     }
+
 }


### PR DESCRIPTION
Improved handling of 404 errors for non-existing owners and pets in the `POST /owners/{ownerId}/pets` endpoint. Also switched to using records for error information to simplify and modernize the code.

This PR addresses [issue #130](https://github.com/spring-petclinic/spring-petclinic-rest/issues/130) and enhances both the error handling and the structure of the error responses.

### Changes:
- Fixed the endpoint to return a 404 Not Found status for non-existing owners or pets instead of a 400 Bad Request.
- Refactored error handling by replacing the previous class-based error representation with Java `record`, which stands for a more concise and immutable way to handle error details.

Please review and merge this update.
