### PR TITLE
Refactor ClinicServiceImpl

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
@@ -24,10 +24,10 @@ import org.springframework.samples.petclinic.repository.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Mostly used as a facade for all Petclinic controllers
@@ -77,14 +77,7 @@ public class ClinicServiceImpl implements ClinicService {
     @Override
     @Transactional(readOnly = true)
     public Visit findVisitById(int visitId) throws DataAccessException {
-        Visit visit = null;
-        try {
-            visit = visitRepository.findById(visitId);
-        } catch (ObjectRetrievalFailureException | EmptyResultDataAccessException e) {
-            // just ignore not found exceptions for Jdbc/Jpa realization
-            return null;
-        }
-        return visit;
+        return findEntityById(() -> visitRepository.findById(visitId));
     }
 
     @Override
@@ -102,14 +95,7 @@ public class ClinicServiceImpl implements ClinicService {
     @Override
     @Transactional(readOnly = true)
     public Vet findVetById(int id) throws DataAccessException {
-        Vet vet = null;
-        try {
-            vet = vetRepository.findById(id);
-        } catch (ObjectRetrievalFailureException | EmptyResultDataAccessException e) {
-            // just ignore not found exceptions for Jdbc/Jpa realization
-            return null;
-        }
-        return vet;
+        return findEntityById(() -> vetRepository.findById(id));
     }
 
     @Override
@@ -145,14 +131,7 @@ public class ClinicServiceImpl implements ClinicService {
     @Override
     @Transactional(readOnly = true)
     public PetType findPetTypeById(int petTypeId) {
-        PetType petType = null;
-        try {
-            petType = petTypeRepository.findById(petTypeId);
-        } catch (ObjectRetrievalFailureException | EmptyResultDataAccessException e) {
-            // just ignore not found exceptions for Jdbc/Jpa realization
-            return null;
-        }
-        return petType;
+        return findEntityById(() -> petTypeRepository.findById(petTypeId));
     }
 
     @Override
@@ -176,14 +155,7 @@ public class ClinicServiceImpl implements ClinicService {
     @Override
     @Transactional(readOnly = true)
     public Specialty findSpecialtyById(int specialtyId) {
-        Specialty specialty = null;
-        try {
-            specialty = specialtyRepository.findById(specialtyId);
-        } catch (ObjectRetrievalFailureException | EmptyResultDataAccessException e) {
-            // just ignore not found exceptions for Jdbc/Jpa realization
-            return null;
-        }
-        return specialty;
+        return findEntityById(() -> specialtyRepository.findById(specialtyId));
     }
 
     @Override
@@ -213,27 +185,13 @@ public class ClinicServiceImpl implements ClinicService {
     @Override
     @Transactional(readOnly = true)
     public Owner findOwnerById(int id) throws DataAccessException {
-        Owner owner = null;
-        try {
-            owner = ownerRepository.findById(id);
-        } catch (ObjectRetrievalFailureException | EmptyResultDataAccessException e) {
-            // just ignore not found exceptions for Jdbc/Jpa realization
-            return null;
-        }
-        return owner;
+        return findEntityById(() -> ownerRepository.findById(id));
     }
 
     @Override
     @Transactional(readOnly = true)
     public Pet findPetById(int id) throws DataAccessException {
-        Pet pet = null;
-        try {
-            pet = petRepository.findById(id);
-        } catch (ObjectRetrievalFailureException | EmptyResultDataAccessException e) {
-            // just ignore not found exceptions for Jdbc/Jpa realization
-            return null;
-        }
-        return pet;
+        return findEntityById(() -> petRepository.findById(id));
     }
 
     @Override
@@ -277,13 +235,16 @@ public class ClinicServiceImpl implements ClinicService {
     @Override
     @Transactional(readOnly = true)
     public List<Specialty> findSpecialtiesByNameIn(Set<String> names) {
-        List<Specialty> specialties = new ArrayList<>();
-        try {
-            specialties = specialtyRepository.findSpecialtiesByNameIn(names);
-        } catch (ObjectRetrievalFailureException | EmptyResultDataAccessException e) {
-            // just ignore not found exceptions for Jdbc/Jpa realization
-            return specialties;
-        }
-        return specialties;
+        return findEntityById(() -> specialtyRepository.findSpecialtiesByNameIn(names));
     }
+
+    private <T> T findEntityById(Supplier<T> supplier) {
+        try {
+            return supplier.get();
+        } catch (ObjectRetrievalFailureException | EmptyResultDataAccessException e) {
+            // Just ignore not found exceptions for Jdbc/Jpa realization
+            return null;
+        }
+    }
+
 }

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
@@ -15,29 +15,19 @@
  */
 package org.springframework.samples.petclinic.service;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.orm.ObjectRetrievalFailureException;
-import org.springframework.samples.petclinic.model.Owner;
-import org.springframework.samples.petclinic.model.Pet;
-import org.springframework.samples.petclinic.model.PetType;
-import org.springframework.samples.petclinic.model.Specialty;
-import org.springframework.samples.petclinic.model.Vet;
-import org.springframework.samples.petclinic.model.Visit;
-import org.springframework.samples.petclinic.repository.OwnerRepository;
-import org.springframework.samples.petclinic.repository.PetRepository;
-import org.springframework.samples.petclinic.repository.PetTypeRepository;
-import org.springframework.samples.petclinic.repository.SpecialtyRepository;
-import org.springframework.samples.petclinic.repository.VetRepository;
-import org.springframework.samples.petclinic.repository.VisitRepository;
+import org.springframework.samples.petclinic.model.*;
+import org.springframework.samples.petclinic.repository.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Mostly used as a facade for all Petclinic controllers
@@ -49,248 +39,248 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class ClinicServiceImpl implements ClinicService {
 
-    private PetRepository petRepository;
-    private VetRepository vetRepository;
-    private OwnerRepository ownerRepository;
-    private VisitRepository visitRepository;
-    private SpecialtyRepository specialtyRepository;
-	private PetTypeRepository petTypeRepository;
+    private final PetRepository petRepository;
+    private final VetRepository vetRepository;
+    private final OwnerRepository ownerRepository;
+    private final VisitRepository visitRepository;
+    private final SpecialtyRepository specialtyRepository;
+    private final PetTypeRepository petTypeRepository;
 
     @Autowired
-     public ClinicServiceImpl(
-       		 PetRepository petRepository,
-    		 VetRepository vetRepository,
-    		 OwnerRepository ownerRepository,
-    		 VisitRepository visitRepository,
-    		 SpecialtyRepository specialtyRepository,
-			 PetTypeRepository petTypeRepository) {
+    public ClinicServiceImpl(
+        PetRepository petRepository,
+        VetRepository vetRepository,
+        OwnerRepository ownerRepository,
+        VisitRepository visitRepository,
+        SpecialtyRepository specialtyRepository,
+        PetTypeRepository petTypeRepository) {
         this.petRepository = petRepository;
         this.vetRepository = vetRepository;
         this.ownerRepository = ownerRepository;
         this.visitRepository = visitRepository;
         this.specialtyRepository = specialtyRepository;
-		this.petTypeRepository = petTypeRepository;
+        this.petTypeRepository = petTypeRepository;
     }
-
-	@Override
-	@Transactional(readOnly = true)
-	public Collection<Pet> findAllPets() throws DataAccessException {
-		return petRepository.findAll();
-	}
-
-	@Override
-	@Transactional
-	public void deletePet(Pet pet) throws DataAccessException {
-		petRepository.delete(pet);
-	}
-
-	@Override
-	@Transactional(readOnly = true)
-	public Visit findVisitById(int visitId) throws DataAccessException {
-		Visit visit = null;
-		try {
-			visit = visitRepository.findById(visitId);
-		} catch (ObjectRetrievalFailureException|EmptyResultDataAccessException e) {
-		// just ignore not found exceptions for Jdbc/Jpa realization
-			return null;
-		}
-		return visit;
-	}
-
-	@Override
-	@Transactional(readOnly = true)
-	public Collection<Visit> findAllVisits() throws DataAccessException {
-		return visitRepository.findAll();
-	}
-
-	@Override
-	@Transactional
-	public void deleteVisit(Visit visit) throws DataAccessException {
-		visitRepository.delete(visit);
-	}
-
-	@Override
-	@Transactional(readOnly = true)
-	public Vet findVetById(int id) throws DataAccessException {
-		Vet vet = null;
-		try {
-			vet = vetRepository.findById(id);
-		} catch (ObjectRetrievalFailureException|EmptyResultDataAccessException e) {
-		// just ignore not found exceptions for Jdbc/Jpa realization
-			return null;
-		}
-		return vet;
-	}
-
-	@Override
-	@Transactional(readOnly = true)
-	public Collection<Vet> findAllVets() throws DataAccessException {
-		return vetRepository.findAll();
-	}
-
-	@Override
-	@Transactional
-	public void saveVet(Vet vet) throws DataAccessException {
-		vetRepository.save(vet);
-	}
-
-	@Override
-	@Transactional
-	public void deleteVet(Vet vet) throws DataAccessException {
-		vetRepository.delete(vet);
-	}
-
-	@Override
-	@Transactional(readOnly = true)
-	public Collection<Owner> findAllOwners() throws DataAccessException {
-		return ownerRepository.findAll();
-	}
-
-	@Override
-	@Transactional
-	public void deleteOwner(Owner owner) throws DataAccessException {
-		ownerRepository.delete(owner);
-	}
-
-	@Override
-    @Transactional(readOnly = true)
-	public PetType findPetTypeById(int petTypeId) {
-		PetType petType = null;
-		try {
-			petType = petTypeRepository.findById(petTypeId);
-		} catch (ObjectRetrievalFailureException|EmptyResultDataAccessException e) {
-		// just ignore not found exceptions for Jdbc/Jpa realization
-			return null;
-		}
-		return petType;
-	}
-
-	@Override
-	@Transactional(readOnly = true)
-	public Collection<PetType> findAllPetTypes() throws DataAccessException {
-		return petTypeRepository.findAll();
-	}
-
-	@Override
-	@Transactional
-	public void savePetType(PetType petType) throws DataAccessException {
-		petTypeRepository.save(petType);
-	}
-
-	@Override
-	@Transactional
-	public void deletePetType(PetType petType) throws DataAccessException {
-		petTypeRepository.delete(petType);
-	}
-
-	@Override
-	@Transactional(readOnly = true)
-	public Specialty findSpecialtyById(int specialtyId) {
-		Specialty specialty = null;
-		try {
-			specialty = specialtyRepository.findById(specialtyId);
-		} catch (ObjectRetrievalFailureException|EmptyResultDataAccessException e) {
-		// just ignore not found exceptions for Jdbc/Jpa realization
-			return null;
-		}
-		return specialty;
-	}
-
-	@Override
-	@Transactional(readOnly = true)
-	public Collection<Specialty> findAllSpecialties() throws DataAccessException {
-		return specialtyRepository.findAll();
-	}
-
-	@Override
-	@Transactional
-	public void saveSpecialty(Specialty specialty) throws DataAccessException {
-		specialtyRepository.save(specialty);
-	}
-
-	@Override
-	@Transactional
-	public void deleteSpecialty(Specialty specialty) throws DataAccessException {
-		specialtyRepository.delete(specialty);
-	}
-
-	@Override
-	@Transactional(readOnly = true)
-	public Collection<PetType> findPetTypes() throws DataAccessException {
-		return petRepository.findPetTypes();
-	}
-
-	@Override
-	@Transactional(readOnly = true)
-	public Owner findOwnerById(int id) throws DataAccessException {
-		Owner owner = null;
-		try {
-			owner = ownerRepository.findById(id);
-		} catch (ObjectRetrievalFailureException|EmptyResultDataAccessException e) {
-		// just ignore not found exceptions for Jdbc/Jpa realization
-			return null;
-		}
-		return owner;
-	}
-
-	@Override
-	@Transactional(readOnly = true)
-	public Pet findPetById(int id) throws DataAccessException {
-		Pet pet = null;
-		try {
-			pet = petRepository.findById(id);
-		} catch (ObjectRetrievalFailureException|EmptyResultDataAccessException e) {
-		// just ignore not found exceptions for Jdbc/Jpa realization
-			return null;
-		}
-		return pet;
-	}
-
-	@Override
-	@Transactional
-	public void savePet(Pet pet) throws DataAccessException {
-		petRepository.save(pet);
-	}
-
-	@Override
-	@Transactional
-	public void saveVisit(Visit visit) throws DataAccessException {
-		visitRepository.save(visit);
-
-	}
-
-	@Override
-	@Transactional(readOnly = true)
-	public Collection<Vet> findVets() throws DataAccessException {
-		return vetRepository.findAll();
-	}
-
-	@Override
-	@Transactional
-	public void saveOwner(Owner owner) throws DataAccessException {
-		ownerRepository.save(owner);
-
-	}
-
-	@Override
-	@Transactional(readOnly = true)
-	public Collection<Owner> findOwnerByLastName(String lastName) throws DataAccessException {
-		return ownerRepository.findByLastName(lastName);
-	}
-
-	@Override
-	@Transactional(readOnly = true)
-	public Collection<Visit> findVisitsByPetId(int petId) {
-		return visitRepository.findByPetId(petId);
-	}
 
     @Override
     @Transactional(readOnly = true)
-    public List<Specialty> findSpecialtiesByNameIn(Set<String> names){
+    public Collection<Pet> findAllPets() throws DataAccessException {
+        return petRepository.findAll();
+    }
+
+    @Override
+    @Transactional
+    public void deletePet(Pet pet) throws DataAccessException {
+        petRepository.delete(pet);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Visit findVisitById(int visitId) throws DataAccessException {
+        Visit visit = null;
+        try {
+            visit = visitRepository.findById(visitId);
+        } catch (ObjectRetrievalFailureException | EmptyResultDataAccessException e) {
+            // just ignore not found exceptions for Jdbc/Jpa realization
+            return null;
+        }
+        return visit;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Collection<Visit> findAllVisits() throws DataAccessException {
+        return visitRepository.findAll();
+    }
+
+    @Override
+    @Transactional
+    public void deleteVisit(Visit visit) throws DataAccessException {
+        visitRepository.delete(visit);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Vet findVetById(int id) throws DataAccessException {
+        Vet vet = null;
+        try {
+            vet = vetRepository.findById(id);
+        } catch (ObjectRetrievalFailureException | EmptyResultDataAccessException e) {
+            // just ignore not found exceptions for Jdbc/Jpa realization
+            return null;
+        }
+        return vet;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Collection<Vet> findAllVets() throws DataAccessException {
+        return vetRepository.findAll();
+    }
+
+    @Override
+    @Transactional
+    public void saveVet(Vet vet) throws DataAccessException {
+        vetRepository.save(vet);
+    }
+
+    @Override
+    @Transactional
+    public void deleteVet(Vet vet) throws DataAccessException {
+        vetRepository.delete(vet);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Collection<Owner> findAllOwners() throws DataAccessException {
+        return ownerRepository.findAll();
+    }
+
+    @Override
+    @Transactional
+    public void deleteOwner(Owner owner) throws DataAccessException {
+        ownerRepository.delete(owner);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PetType findPetTypeById(int petTypeId) {
+        PetType petType = null;
+        try {
+            petType = petTypeRepository.findById(petTypeId);
+        } catch (ObjectRetrievalFailureException | EmptyResultDataAccessException e) {
+            // just ignore not found exceptions for Jdbc/Jpa realization
+            return null;
+        }
+        return petType;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Collection<PetType> findAllPetTypes() throws DataAccessException {
+        return petTypeRepository.findAll();
+    }
+
+    @Override
+    @Transactional
+    public void savePetType(PetType petType) throws DataAccessException {
+        petTypeRepository.save(petType);
+    }
+
+    @Override
+    @Transactional
+    public void deletePetType(PetType petType) throws DataAccessException {
+        petTypeRepository.delete(petType);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Specialty findSpecialtyById(int specialtyId) {
+        Specialty specialty = null;
+        try {
+            specialty = specialtyRepository.findById(specialtyId);
+        } catch (ObjectRetrievalFailureException | EmptyResultDataAccessException e) {
+            // just ignore not found exceptions for Jdbc/Jpa realization
+            return null;
+        }
+        return specialty;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Collection<Specialty> findAllSpecialties() throws DataAccessException {
+        return specialtyRepository.findAll();
+    }
+
+    @Override
+    @Transactional
+    public void saveSpecialty(Specialty specialty) throws DataAccessException {
+        specialtyRepository.save(specialty);
+    }
+
+    @Override
+    @Transactional
+    public void deleteSpecialty(Specialty specialty) throws DataAccessException {
+        specialtyRepository.delete(specialty);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Collection<PetType> findPetTypes() throws DataAccessException {
+        return petRepository.findPetTypes();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Owner findOwnerById(int id) throws DataAccessException {
+        Owner owner = null;
+        try {
+            owner = ownerRepository.findById(id);
+        } catch (ObjectRetrievalFailureException | EmptyResultDataAccessException e) {
+            // just ignore not found exceptions for Jdbc/Jpa realization
+            return null;
+        }
+        return owner;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Pet findPetById(int id) throws DataAccessException {
+        Pet pet = null;
+        try {
+            pet = petRepository.findById(id);
+        } catch (ObjectRetrievalFailureException | EmptyResultDataAccessException e) {
+            // just ignore not found exceptions for Jdbc/Jpa realization
+            return null;
+        }
+        return pet;
+    }
+
+    @Override
+    @Transactional
+    public void savePet(Pet pet) throws DataAccessException {
+        petRepository.save(pet);
+    }
+
+    @Override
+    @Transactional
+    public void saveVisit(Visit visit) throws DataAccessException {
+        visitRepository.save(visit);
+
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Collection<Vet> findVets() throws DataAccessException {
+        return vetRepository.findAll();
+    }
+
+    @Override
+    @Transactional
+    public void saveOwner(Owner owner) throws DataAccessException {
+        ownerRepository.save(owner);
+
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Collection<Owner> findOwnerByLastName(String lastName) throws DataAccessException {
+        return ownerRepository.findByLastName(lastName);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Collection<Visit> findVisitsByPetId(int petId) {
+        return visitRepository.findByPetId(petId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Specialty> findSpecialtiesByNameIn(Set<String> names) {
         List<Specialty> specialties = new ArrayList<>();
         try {
             specialties = specialtyRepository.findSpecialtiesByNameIn(names);
-        } catch (ObjectRetrievalFailureException|EmptyResultDataAccessException e) {
+        } catch (ObjectRetrievalFailureException | EmptyResultDataAccessException e) {
             // just ignore not found exceptions for Jdbc/Jpa realization
             return specialties;
         }


### PR DESCRIPTION
### Summary

This PR makes all fields in the `ClinicServiceImpl` class `final` to ensure they are immutable after initialization. It also removes some redundant imports.

### Changes

- Made fields in `ClinicServiceImpl` `final`.
- Updated the constructor to initialize these fields.
- Removed unnecessary imports.

- UPD: added private helper method to extract common entity retrieval logic