### PR TITLE
Bump openapi-generator-maven-plugin from 6.3.0 to 7.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
         <!-- Maven plugins -->
         <jacoco.version>0.8.11</jacoco.version>
-        <openapi-generator-maven-plugin.version>6.3.0</openapi-generator-maven-plugin.version>
+        <openapi-generator-maven-plugin.version>7.8.0</openapi-generator-maven-plugin.version>
         <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
 
         <!-- Docker -->

--- a/src/main/resources/openapi.yml
+++ b/src/main/resources/openapi.yml
@@ -1888,7 +1888,7 @@ components:
           title: Message
           description: The validation message.
           type: string
-          example: "[Path '/lastName'] Instance type (null) does not match any allowed primitive type (allowed: [\"string\"])"
+          example: "[Path '/lastName'] Instance type (null) does not match any allowed primitive type (allowed: ['string'])"
           readOnly: true
       required:
         - message


### PR DESCRIPTION
Required to fix the ValidationMessage example