### PR TITLE
fix: MapStruct reporting policy change (from issue #157)

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/mapper/OwnerMapper.java
+++ b/src/main/java/org/springframework/samples/petclinic/mapper/OwnerMapper.java
@@ -1,6 +1,7 @@
 package org.springframework.samples.petclinic.mapper;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
 import org.springframework.samples.petclinic.rest.dto.OwnerDto;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.rest.dto.OwnerFieldsDto;
@@ -11,7 +12,7 @@ import java.util.List;
 /**
  * Maps Owner & OwnerDto using Mapstruct
  */
-@Mapper(uses = PetMapper.class)
+@Mapper(uses = PetMapper.class, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface OwnerMapper {
 
     OwnerDto toOwnerDto(Owner owner);

--- a/src/main/java/org/springframework/samples/petclinic/mapper/PetMapper.java
+++ b/src/main/java/org/springframework/samples/petclinic/mapper/PetMapper.java
@@ -2,6 +2,7 @@ package org.springframework.samples.petclinic.mapper;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 import org.springframework.samples.petclinic.rest.dto.PetDto;
 import org.springframework.samples.petclinic.rest.dto.PetFieldsDto;
 import org.springframework.samples.petclinic.rest.dto.PetTypeDto;
@@ -13,7 +14,7 @@ import java.util.Collection;
 /**
  * Map Pet & PetDto using mapstruct
  */
-@Mapper
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface PetMapper {
 
     @Mapping(source = "owner.id", target = "ownerId")

--- a/src/main/java/org/springframework/samples/petclinic/mapper/PetTypeMapper.java
+++ b/src/main/java/org/springframework/samples/petclinic/mapper/PetTypeMapper.java
@@ -1,6 +1,7 @@
 package org.springframework.samples.petclinic.mapper;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
 import org.springframework.samples.petclinic.rest.dto.PetTypeDto;
 import org.springframework.samples.petclinic.model.PetType;
 import org.springframework.samples.petclinic.rest.dto.PetTypeFieldsDto;
@@ -11,7 +12,7 @@ import java.util.List;
 /**
  * Map PetType & PetTypeDto using mapstruct
  */
-@Mapper
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface PetTypeMapper {
 
     PetType toPetType(PetTypeDto petTypeDto);

--- a/src/main/java/org/springframework/samples/petclinic/mapper/SpecialtyMapper.java
+++ b/src/main/java/org/springframework/samples/petclinic/mapper/SpecialtyMapper.java
@@ -1,6 +1,7 @@
 package org.springframework.samples.petclinic.mapper;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
 import org.springframework.samples.petclinic.rest.dto.SpecialtyDto;
 import org.springframework.samples.petclinic.model.Specialty;
 
@@ -9,7 +10,7 @@ import java.util.Collection;
 /**
  * Map Specialty & SpecialtyDto using mapstruct
  */
-@Mapper
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface SpecialtyMapper {
     Specialty toSpecialty(SpecialtyDto specialtyDto);
 

--- a/src/main/java/org/springframework/samples/petclinic/mapper/UserMapper.java
+++ b/src/main/java/org/springframework/samples/petclinic/mapper/UserMapper.java
@@ -1,6 +1,7 @@
 package org.springframework.samples.petclinic.mapper;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
 import org.springframework.samples.petclinic.rest.dto.RoleDto;
 import org.springframework.samples.petclinic.rest.dto.UserDto;
 import org.springframework.samples.petclinic.model.Role;
@@ -11,7 +12,7 @@ import java.util.Collection;
 /**
  * Map User/Role & UserDto/RoleDto using mapstruct
  */
-@Mapper
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface UserMapper {
     Role toRole(RoleDto roleDto);
 

--- a/src/main/java/org/springframework/samples/petclinic/mapper/VetMapper.java
+++ b/src/main/java/org/springframework/samples/petclinic/mapper/VetMapper.java
@@ -1,6 +1,7 @@
 package org.springframework.samples.petclinic.mapper;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
 import org.springframework.samples.petclinic.rest.dto.VetDto;
 import org.springframework.samples.petclinic.model.Vet;
 import org.springframework.samples.petclinic.rest.dto.VetFieldsDto;
@@ -10,7 +11,7 @@ import java.util.Collection;
 /**
  * Map Vet & VetoDto using mapstruct
  */
-@Mapper(uses = SpecialtyMapper.class)
+@Mapper(uses = SpecialtyMapper.class, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface VetMapper {
     Vet toVet(VetDto vetDto);
 

--- a/src/main/java/org/springframework/samples/petclinic/mapper/VisitMapper.java
+++ b/src/main/java/org/springframework/samples/petclinic/mapper/VisitMapper.java
@@ -2,6 +2,7 @@ package org.springframework.samples.petclinic.mapper;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 import org.springframework.samples.petclinic.rest.dto.VisitDto;
 import org.springframework.samples.petclinic.model.Visit;
 import org.springframework.samples.petclinic.rest.dto.VisitFieldsDto;
@@ -11,7 +12,7 @@ import java.util.Collection;
 /**
  * Map Visit & VisitDto using mapstruct
  */
-@Mapper(uses = PetMapper.class)
+@Mapper(uses = PetMapper.class, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface VisitMapper {
     Visit toVisit(VisitDto visitDto);
 


### PR DESCRIPTION
Change in the reporting policy of Mapper interfaces, suppressing log warnings regarding attributes not mapped by MapStruct.
Change regarding issue #157

![image](https://github.com/user-attachments/assets/6a3b1623-2e7e-4189-9ae7-500304955492)
