### PR TITLE
Fix Java compiler version to 17 and remove duplicated maven plugin versions #194

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <maven.checkstyle-plugin.version>3.6.0</maven.checkstyle-plugin.version>
         <maven.clean-plugin.version>3.4.0</maven.clean-plugin.version>
         <maven.compiler-plugin.version>3.13.0</maven.compiler-plugin.version>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
         <maven.dependency-plugin.version>3.8.1</maven.dependency-plugin.version>
         <maven.deploy-plugin.version>3.1.3</maven.deploy-plugin.version>
         <maven.enforcer-plugin.version>3.5.0</maven.enforcer-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <maven.checkstyle-plugin.version>3.6.0</maven.checkstyle-plugin.version>
         <maven.clean-plugin.version>3.4.0</maven.clean-plugin.version>
         <maven.compiler-plugin.version>3.13.0</maven.compiler-plugin.version>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
         <maven.dependency-plugin.version>3.8.1</maven.dependency-plugin.version>
         <maven.deploy-plugin.version>3.1.3</maven.deploy-plugin.version>
         <maven.enforcer-plugin.version>3.5.0</maven.enforcer-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,6 @@
         <maven.checkstyle-plugin.version>3.6.0</maven.checkstyle-plugin.version>
         <maven.clean-plugin.version>3.4.0</maven.clean-plugin.version>
         <maven.compiler-plugin.version>3.13.0</maven.compiler-plugin.version>
-        <maven.compiler.release>${java.version}</maven.compiler.release>
         <maven.dependency-plugin.version>3.8.1</maven.dependency-plugin.version>
         <maven.deploy-plugin.version>3.1.3</maven.deploy-plugin.version>
         <maven.enforcer-plugin.version>3.5.0</maven.enforcer-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,31 +27,19 @@
         <jaxb-api.version>2.3.1</jaxb-api.version>
 
         <!-- Maven plugins and supporting properties -->
-        <maven.build-helper-plugin.version>3.6.0</maven.build-helper-plugin.version>
         <maven.checkstyle-plugin.version>3.6.0</maven.checkstyle-plugin.version>
-        <maven.clean-plugin.version>3.4.0</maven.clean-plugin.version>
-        <maven.compiler-plugin.version>3.13.0</maven.compiler-plugin.version>
-        <maven.dependency-plugin.version>3.8.1</maven.dependency-plugin.version>
-        <maven.deploy-plugin.version>3.1.3</maven.deploy-plugin.version>
-        <maven.enforcer-plugin.version>3.5.0</maven.enforcer-plugin.version>
         <maven.exec-plugin.version>3.5.0</maven.exec-plugin.version>
-        <maven.install-plugin.version>3.1.3</maven.install-plugin.version>
         <maven.jacoco-plugin.version>0.8.12</maven.jacoco-plugin.version>
-        <maven.jar-plugin.version>3.4.2</maven.jar-plugin.version>
-        <maven.javadoc-plugin.version>3.11.2</maven.javadoc-plugin.version>
         <maven.jxr-plugin.version>3.6.0</maven.jxr-plugin.version>
         <maven.license-plugin.version>2.5.0</maven.license-plugin.version>
         <maven.openapi-generator-plugin.version>7.11.0</maven.openapi-generator-plugin.version>
         <maven.project-info-reports-plugin.version>3.8.0</maven.project-info-reports-plugin.version>
         <maven.rat-plugin.version>0.16.1</maven.rat-plugin.version>
+        <maven.refactor-first-plugin.version>0.6.2</maven.refactor-first-plugin.version>
         <maven.release-plugin.version>3.1.1</maven.release-plugin.version>
-        <maven.resources-plugin.version>3.3.1</maven.resources-plugin.version>
         <maven.site-plugin.version>3.21.0</maven.site-plugin.version>
-        <maven.source-plugin.version>3.3.1</maven.source-plugin.version>
         <maven.spotbugs-plugin.version>4.8.6.6</maven.spotbugs-plugin.version>
-        <maven.surefire-plugin.version>3.5.2</maven.surefire-plugin.version>
         <maven.version>3.9.9</maven.version>
-        <maven.versions-plugin.version>2.18.0</maven.versions-plugin.version>
 
         <!-- Docker -->
         <docker.jib-maven-plugin.version>3.4.4</docker.jib-maven-plugin.version>
@@ -233,7 +221,7 @@
             <plugin>
                 <groupId>org.hjug.refactorfirst.plugin</groupId>
                 <artifactId>refactor-first-maven-plugin</artifactId>
-                <version>0.6.2</version>
+                <version>${maven.refactor-first-plugin.version}</version>
                 <!-- optional -->
                 <configuration>
                     <showDetails>true</showDetails>
@@ -397,7 +385,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>${maven.build-helper-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>add-source</id>
@@ -416,7 +403,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <annotationProcessorPaths>
                         <path>


### PR DESCRIPTION
@karianna and @Bragolgirith I remove all maven plugin versions already declared into the inherited `spring-boot-dependencies` parent pom.
