### PR TITLE
Updates Swagger @Configuration class

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/config/SwaggerConfig.java
+++ b/src/main/java/org/springframework/samples/petclinic/config/SwaggerConfig.java
@@ -43,7 +43,7 @@ public class SwaggerConfig {
             .info(new Info()
                 .title("REST Petclinic backend API documentation")
                 .version("1.0")
-                .termsOfService("https://github.com/spring-petclinic/spring-petclinic-rest/blob/master/readme.md")
+                .termsOfService("https://github.com/spring-petclinic/spring-petclinic-rest/blob/master/terms.txt")
                 .description(
                     "This is the REST API documentation of the Spring Petclinic backend. " +
                         "If authentication is enabled, use admin/admin when calling the APIs")

--- a/src/main/java/org/springframework/samples/petclinic/config/SwaggerConfig.java
+++ b/src/main/java/org/springframework/samples/petclinic/config/SwaggerConfig.java
@@ -29,7 +29,7 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
 
 /**
- * Java config for Springfox swagger documentation plugin
+ * Java config for springdoc-openapi API documentation library
  *
  * @author Vitaliy Fedoriv
  */
@@ -38,13 +38,17 @@ public class SwaggerConfig {
 
     @Bean
     OpenAPI customOpenAPI() {
-
-        return new OpenAPI().components(new Components()).info(new Info()
-                .title("REST Petclinic backend Api Documentation").version("1.0")
-                .termsOfService("Petclinic backend terms of service")
+        return new OpenAPI()
+            .components(new Components())
+            .info(new Info()
+                .title("REST Petclinic backend API documentation")
+                .version("1.0")
+                .termsOfService("https://github.com/spring-petclinic/spring-petclinic-rest/blob/master/readme.md")
                 .description(
-                        "This is REST API documentation of the Spring Petclinic backend. If authentication is enabled, when calling the APIs use admin/admin")
-                .license(swaggerLicense()).contact(swaggerContact()));
+                    "This is the REST API documentation of the Spring Petclinic backend. " +
+                        "If authentication is enabled, use admin/admin when calling the APIs")
+                .license(swaggerLicense())
+                .contact(swaggerContact()));
     }
 
     private Contact swaggerContact() {

--- a/terms.txt
+++ b/terms.txt
@@ -1,0 +1,24 @@
+Terms of Service
+
+1. Educational Use Only
+
+This API is provided solely for demonstration and learning purposes. It should not be used in
+production environments.
+
+2. No Guarantee of Availability or Support
+
+This is an open-source project maintained by the Spring Petclinic community, as such, no service
+availability or support guarantee is provided.
+
+3. No Liability
+
+The project maintainers and contributors disclaim any liability for the use of this code in critical
+or commercial environments.
+
+4. License (Apache 2.0)
+
+The API and its source code are distributed under the Apache 2.0 license. You are free to use,
+modify, and redistribute it, provided that you comply with the terms of the license.
+
+
+Note: The endpoints and structure of this API are subject to change at any time without notice.


### PR DESCRIPTION
This PR replaces the Springfox mention in the Javadoc by the current Swagger UI library in use `springdoc-api`.

It also updates the text inserted into the Info builder and adds some line breaks to the code.

I wonder if you have some URL to set the `termsOfService`?
Seems like it should be a link, not a text.