### PR TITLE
 Remove the POST endpoint from the /api/pets ressource

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,6 @@ API documentation (OAS 3.1) is accessible at: [http://localhost:9966/petclinic/v
 | **Pets** |  |  |
 | **GET** | `/api/pets` | Retrieve all pets |
 | **GET** | `/api/pets/{petId}` | Get a pet by ID |
-| **POST** | `/api/pets` | Add a new pet |
 | **PUT** | `/api/pets/{petId}` | Update pet details |
 | **DELETE** | `/api/pets/{petId}` | Delete a pet |
 | **Vets** |  |  |

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/PetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/PetRestController.java
@@ -16,7 +16,6 @@
 
 package org.springframework.samples.petclinic.rest.controller;
 
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.samples.petclinic.mapper.PetMapper;
@@ -28,7 +27,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/PetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/PetRestController.java
@@ -97,13 +97,4 @@ public class PetRestController implements PetsApi {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
-    @PreAuthorize("hasRole(@roles.OWNER_ADMIN)")
-    @Override
-    public ResponseEntity<PetDto> addPet(PetDto petDto) {
-        HttpHeaders headers = new HttpHeaders();
-        Pet pet = petMapper.toPet(petDto);
-        this.clinicService.savePet(pet);
-        headers.setLocation(UriComponentsBuilder.newInstance().path("/api/pets/{id}").buildAndExpand(pet.getId()).toUri());
-        return new ResponseEntity<>(petMapper.toPetDto(pet), headers, HttpStatus.CREATED);
-    }
 }

--- a/src/main/resources/openapi.yml
+++ b/src/main/resources/openapi.yml
@@ -798,56 +798,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
-    post:
-      tags:
-        - pet
-      operationId: addPet
-      summary: Create a pet
-      description: Creates a pet .
-      requestBody:
-        description: The pet
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Pet'
-        required: true
-      responses:
-        201:
-          description: Pet type created successfully.
-          headers:
-            ETag:
-              description: An ID for this version of the response.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Pet'
-        304:
-          description: Not modified.
-          headers:
-            ETag:
-              description: An ID for this version of the response.
-              schema:
-                type: string
-        400:
-          description: Bad request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProblemDetail'
-        404:
-          description: Pet not found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProblemDetail'
-        500:
-          description: Server error.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProblemDetail'
   /pets/{petId}:
     get:
       tags:

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/PetRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/PetRestControllerTests.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.samples.petclinic.mapper.PetMapper;
 import org.springframework.samples.petclinic.model.Pet;

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/PetRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/PetRestControllerTests.java
@@ -220,31 +220,4 @@ class PetRestControllerTests {
             .andExpect(status().isNotFound());
     }
 
-    @Test
-    @WithMockUser(roles = "OWNER_ADMIN")
-    void testAddPetSuccess() throws Exception {
-        PetDto newPet = pets.get(0);
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule());
-        String newPetAsJSON = mapper.writeValueAsString(newPet);
-        given(this.clinicService.findPetById(3)).willReturn(petMapper.toPet(pets.get(0)));
-        this.mockMvc.perform(post("/api/pets")
-                .content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(status().isCreated())
-            .andExpect(header().string(HttpHeaders.LOCATION, "/api/pets/3"));
-    }
-
-    @Test
-    @WithMockUser(roles = "OWNER_ADMIN")
-    void testAddPetError() throws Exception {
-        PetDto newPet = pets.get(0);
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule());
-        String newPetAsJSON = mapper.writeValueAsString(newPet);
-        given(this.clinicService.findPetById(999)).willReturn(null);
-        this.mockMvc.perform(post("/api/pets")
-                // set empty JSON to force 400 error
-                .content("{}").accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(status().isBadRequest());
-    }
 }


### PR DESCRIPTION
#139 simplify the API by removing the POST to the /petclinic/api/pets ressource.