### PR TITLE
Extending first and lastname patterns #148

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ springboot-petclinic-server/
 
 # Mac OS X indexing
 .DS_Store
+
+# asdf generated files
+.tool-versions
+.factorypath

--- a/src/main/resources/openapi.yml
+++ b/src/main/resources/openapi.yml
@@ -1924,7 +1924,7 @@ components:
           type: string
           minLength: 1
           maxLength: 30
-          pattern: '^[a-zA-Z]*$'
+          pattern: "^[\\p{L}]+([ '-][\\p{L}]+){0,2}$"
           example: George
         lastName:
           title: Last name
@@ -1932,7 +1932,7 @@ components:
           type: string
           minLength: 1
           maxLength: 30
-          pattern: '^[a-zA-Z]*$'
+          pattern: "^[\\p{L}]+([ '-][\\p{L}]+){0,2}\\.?$"
           example: Franklin
         address:
           title: Address
@@ -2054,7 +2054,7 @@ components:
           type: string
           minLength: 1
           maxLength: 30
-          pattern: '^[a-zA-Z]*$'
+          pattern: "^[\\p{L}]+([ '-][\\p{L}]+){0,2}$"
           example: 'James'
         lastName:
           title: Last name
@@ -2062,7 +2062,7 @@ components:
           type: string
           minLength: 1
           maxLength: 30
-          pattern: '^[a-zA-Z]*$'
+          pattern: "^[\\p{L}]+([ '-][\\p{L}]+){0,2}\\.?$"
           example: 'Carter'
         specialties:
           title: Specialties


### PR DESCRIPTION
## 💡 What does this PR do?

This PR updates the validation rules in the OpenAPI spec for OwnerFields and VetFields to ensure proper data validation when creating or updating entities.

## ✨ Changes

- Updated regex patterns for:
  - firstName: accepts names with optional hyphens, apostrophes, and spaces.
  - lastName: same as above, but allows an optional trailing dot (e.g., "Jr.")
- Ensured all constraints reflect the intended validation logic (minLength, maxLength, pattern).
- Regenerated DTOs accordingly using OpenAPI generator (./mvnw clean compile).

## 🧪 Tests

- Manual test with Postman/Swagger to confirm the new validation rules are active.
- Ran ./mvnw verify — all tests pass.

## 🔗 Related Issue

Fixes #148 

---

Let me know if you need any more adjustments. 🚀