### PR TITLE
 Applying MapStruct compiler options only during main compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -409,26 +409,31 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>org.mapstruct</groupId>
-                            <artifactId>mapstruct-processor</artifactId>
-                            <version>${mapstruct.version}</version>
-                        </path>
-                    </annotationProcessorPaths>
-                    <compilerArgs>
-                        <compilerArg>
-                            -Amapstruct.suppressGeneratorTimestamp=true
-                        </compilerArg>
-                        <compilerArg>
-                            -Amapstruct.suppressGeneratorVersionInfoComment=true
-                        </compilerArg>
-                        <compilerArg>
-                            -Amapstruct.defaultComponentModel=spring
-                        </compilerArg>
-                    </compilerArgs>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.mapstruct</groupId>
+                                    <artifactId>mapstruct-processor</artifactId>
+                                    <version>${mapstruct.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                            <compilerArgs>
+                                <compilerArg>
+                                    -Amapstruct.suppressGeneratorTimestamp=true
+                                </compilerArg>
+                                <compilerArg>
+                                    -Amapstruct.suppressGeneratorVersionInfoComment=true
+                                </compilerArg>
+                                <compilerArg>
+                                    -Amapstruct.defaultComponentModel=spring
+                                </compilerArg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## 💡 What does this PR do?

This PR updates the `maven-compiler-plugin` configuration to apply MapStruct-specific compiler options only during the main compilation phase. This prevents warnings from appearing during test compilation, where MapStruct is not used.

## ✨ Changes

- Moved MapStruct-related compiler options into an `<execution>` block with `id` set to `default-compile`.
- Ensured the options are applied only during the `compile` phase, not `testCompile`.
- Cleaned up build output by avoiding irrelevant warnings.

## 🧪 Tests

- Ran `./mvnw clean verify` — all tests pass.
- Confirmed the warning is no longer present during `testCompile`.

## 🔗 Related Issue

Fixes #187 

---

Let me know if you need any more adjustments. 🚀