### PR TITLE
Adding missing PUT method in OwnerRestController class With Integration Tests

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
@@ -149,6 +149,22 @@ public class OwnerRestController implements OwnersApi {
 
     @PreAuthorize("hasRole(@roles.OWNER_ADMIN)")
     @Override
+    public ResponseEntity<Void> updateOwnersPet(Integer ownerId, Integer petId, PetFieldsDto petFieldsDto) {
+        Owner currentOwner = this.clinicService.findOwnerById(ownerId);
+        Pet currentPet = this.clinicService.findPetById(petId);
+        if (currentOwner == null || currentPet == null) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+        currentPet.setBirthDate(petFieldsDto.getBirthDate());
+        currentPet.setName(petFieldsDto.getName());
+        currentPet.getType().setId(petFieldsDto.getType().getId());
+        currentPet.getType().setName(petFieldsDto.getType().getName());
+        this.clinicService.savePet(currentPet);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @PreAuthorize("hasRole(@roles.OWNER_ADMIN)")
+    @Override
     public ResponseEntity<VisitDto> addVisitToOwner(Integer ownerId, Integer petId, VisitFieldsDto visitFieldsDto) {
         HttpHeaders headers = new HttpHeaders();
         Visit visit = visitMapper.toVisit(visitFieldsDto);

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
@@ -151,16 +151,17 @@ public class OwnerRestController implements OwnersApi {
     @Override
     public ResponseEntity<Void> updateOwnersPet(Integer ownerId, Integer petId, PetFieldsDto petFieldsDto) {
         Owner currentOwner = this.clinicService.findOwnerById(ownerId);
-        Pet currentPet = this.clinicService.findPetById(petId);
-        if (currentOwner == null || currentPet == null) {
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        if (currentOwner != null) {
+            Pet currentPet = this.clinicService.findPetById(petId);
+            if (currentPet != null) {
+                currentPet.setBirthDate(petFieldsDto.getBirthDate());
+                currentPet.setName(petFieldsDto.getName());
+                currentPet.setType(petMapper.toPetType(petFieldsDto.getType()));
+                this.clinicService.savePet(currentPet);
+                return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+            }
         }
-        currentPet.setBirthDate(petFieldsDto.getBirthDate());
-        currentPet.setName(petFieldsDto.getName());
-        currentPet.getType().setId(petFieldsDto.getType().getId());
-        currentPet.getType().setName(petFieldsDto.getType().getName());
-        this.clinicService.savePet(currentPet);
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
 
     @PreAuthorize("hasRole(@roles.OWNER_ADMIN)")

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
@@ -430,4 +430,66 @@ class OwnerRestControllerTests {
     }
 
 
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testUpdateOwnersPetSuccess() throws Exception {
+        int ownerId = owners.get(0).getId();
+        int petId = pets.get(0).getId();
+        given(this.clinicService.findOwnerById(ownerId)).willReturn(ownerMapper.toOwner(owners.get(0)));
+        given(this.clinicService.findPetById(petId)).willReturn(petMapper.toPet(pets.get(0)));
+        PetDto updatedPetDto = pets.get(0);
+        updatedPetDto.setName("Rex");
+        updatedPetDto.setBirthDate(LocalDate.of(2020, 1, 15));
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        String updatedPetAsJSON = mapper.writeValueAsString(updatedPetDto);
+        this.mockMvc.perform(put("/api/owners/" + ownerId + "/pets/" + petId)
+                .content(updatedPetAsJSON)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testUpdateOwnersPetOwnerNotFound() throws Exception {
+        int ownerId = 0;
+        int petId = pets.get(0).getId();
+        given(this.clinicService.findOwnerById(ownerId)).willReturn(null);
+        PetDto petDto = pets.get(0);
+        petDto.setName("Thor");
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        String updatedPetAsJSON = mapper.writeValueAsString(petDto);
+        this.mockMvc.perform(put("/api/owners/" + ownerId + "/pets/" + petId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatedPetAsJSON))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testUpdateOwnersPetPetNotFound() throws Exception {
+        int ownerId = owners.get(0).getId();
+        int petId = 0;
+        given(this.clinicService.findOwnerById(ownerId)).willReturn(ownerMapper.toOwner(owners.get(0)));
+        given(this.clinicService.findPetById(petId)).willReturn(null);
+        PetDto petDto = pets.get(0);
+        petDto.setName("Ghost");
+        petDto.setBirthDate(LocalDate.of(2020, 1, 1));
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        String updatedPetAsJSON = mapper.writeValueAsString(petDto);
+        this.mockMvc.perform(put("/api/owners/" + ownerId + "/pets/" + petId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatedPetAsJSON))
+            .andExpect(status().isNotFound());
+    }
+
 }


### PR DESCRIPTION
## 💡 What does this PR do?

This PR implements the `updateOwnersPet` method in the `OwnerRestController` class, allowing pet updates for a given owner.

## ✨ Changes
- Validates:
  -  Update a pet for a givin owner with success (204 No Content)
  - Owner existence (404 if Not Found)
  - Pet existence (404 if Not Found)
- Updates the pet’s:
  - Name.
  - Birthdate.
  - Type (if provided and valid)
- Returns `204 No Content` on successful update.

## 🧪 Tests

- Integration tests implemented:
  - testUpdateOwnersPetSuccess
  - testUpdateOwnersPetOwnerNotFound
  - testUpdateOwnersPetPetNotFound

- Ran `mvn clean verify` - all tests passed.

## 🔗 Related Issue

Fix #220