### PR TITLE
Resolved mismatch stubbings in VetRestControllerTests.java

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/VetRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/VetRestControllerTests.java
@@ -106,7 +106,7 @@ class VetRestControllerTests {
     @Test
     @WithMockUser(roles="VET_ADMIN")
     void testGetVetNotFound() throws Exception {
-    	given(this.clinicService.findVetById(-1)).willReturn(null);
+    	given(this.clinicService.findVetById(999)).willReturn(null);
         this.mockMvc.perform(get("/api/vets/999")
         	.accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound());
@@ -213,7 +213,7 @@ class VetRestControllerTests {
     	Vet newVet = vets.get(0);
     	ObjectMapper mapper = new ObjectMapper();
         String newVetAsJSON = mapper.writeValueAsString(vetMapper.toVetDto(newVet));
-    	given(this.clinicService.findVetById(-1)).willReturn(null);
+    	given(this.clinicService.findVetById(999)).willReturn(null);
     	this.mockMvc.perform(delete("/api/vets/999")
     		.content(newVetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
         	.andExpect(status().isNotFound());


### PR DESCRIPTION
I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In tests `testGetVetNotFound` and `testDeleteVetError`:

* The `findVetById` method for the `clinicService` object:
i) is stubbed with argument `-1`
ii) during test execution the method is actually called with argument `999`, resulting in mismatch stubbings

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback.