### PR TITLE
docs: add note to run 'mvn clean install' before IDE import

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,17 @@ cd spring-petclinic-rest
 ./mvnw spring-boot:run
 ```
 
+
+```markdown
+> ⚠️ **Important: Build the Project Before Opening in an IDE**
+
+If you open this project in an IDE (like IntelliJ or Eclipse) before building it, you may see missing classes or unresolved entities (e.g., `Pet`, `Visit`, `User`, or generated DTOs).
+
+To fix this:
+```sh
+./mvnw clean install
+
+
 ### With Docker
 ```sh
 docker run -p 9966:9966 springcommunity/spring-petclinic-rest


### PR DESCRIPTION
When opening the project without building it first, some entities appear missing in IDEs like IntelliJ. This update adds a troubleshooting note to help first-time contributors avoid confusion.