### PR TITLE
Added pagination and sorting support for Owners API (#11)

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/repository/OwnerRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/OwnerRepository.java
@@ -20,6 +20,9 @@ import java.util.Collection;
 import org.springframework.dao.DataAccessException;
 import org.springframework.samples.petclinic.model.BaseEntity;
 import org.springframework.samples.petclinic.model.Owner;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 
 /**
  * Repository class for <code>Owner</code> domain objects All method names are compliant with Spring Data naming
@@ -60,22 +63,29 @@ public interface OwnerRepository {
      * @see BaseEntity#isNew
      */
     void save(Owner owner) throws DataAccessException;
-    
+
     /**
-     * Retrieve <code>Owner</code>s from the data store, returning all owners 
+     * Retrieve <code>Owner</code>s from the data store, returning all owners
      *
      * @return a <code>Collection</code> of <code>Owner</code>s (or an empty <code>Collection</code> if none
      * found)
      */
 	Collection<Owner> findAll() throws DataAccessException;
-	
+
     /**
      * Delete an <code>Owner</code> to the data store by <code>Owner</code>.
      *
      * @param owner the <code>Owner</code> to delete
-     * 
+     *
      */
 	void delete(Owner owner) throws DataAccessException;
 
+    default Page<Owner> findAll(Pageable pageable) throws DataAccessException {
+        throw new UnsupportedOperationException("Paging not supported for this profile");
+    }
+
+    default Page<Owner> findByLastName(String lastName, Pageable pageable) throws DataAccessException {
+        throw new UnsupportedOperationException("Paging not supported for this profile");
+    }
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataOwnerRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataOwnerRepository.java
@@ -23,6 +23,8 @@ import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.repository.OwnerRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 /**
  * Spring Data JPA specialization of the {@link OwnerRepository} interface
@@ -41,4 +43,6 @@ public interface SpringDataOwnerRepository extends OwnerRepository, Repository<O
     @Override
     @Query("SELECT owner FROM Owner owner left join fetch owner.pets WHERE owner.id =:id")
     Owner findById(@Param("id") int id);
+    Page<Owner> findAll(Pageable pageable);
+    Page<Owner> findByLastName(String lastName, Pageable pageable);
 }

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicService.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicService.java
@@ -26,6 +26,8 @@ import org.springframework.samples.petclinic.model.PetType;
 import org.springframework.samples.petclinic.model.Specialty;
 import org.springframework.samples.petclinic.model.Vet;
 import org.springframework.samples.petclinic.model.Visit;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 /**
  * Mostly used as a facade so all controllers have a single point of entry
@@ -67,4 +69,6 @@ public interface ClinicService {
 	void deleteSpecialty(Specialty specialty) throws DataAccessException;
 
     List<Specialty> findSpecialtiesByNameIn(Set<String> names) throws DataAccessException;
+    Page<Owner> findAllOwners(Pageable pageable);
+    Page<Owner> findOwnerByLastName(String lastName, Pageable pageable);
 }

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
@@ -22,6 +22,9 @@ import org.springframework.samples.petclinic.model.*;
 import org.springframework.samples.petclinic.repository.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageImpl;
 
 import java.util.Collection;
 import java.util.List;
@@ -243,6 +246,34 @@ public class ClinicServiceImpl implements ClinicService {
         } catch (ObjectRetrievalFailureException | EmptyResultDataAccessException e) {
             // Just ignore not found exceptions for Jdbc/Jpa realization
             return null;
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<Owner> findAllOwners(Pageable pageable) {
+        try {
+            return ownerRepository.findAll(pageable);
+        } catch (UnsupportedOperationException ex) {
+            // Fallback for jdbc/jpa profiles
+            var all = new java.util.ArrayList<>(ownerRepository.findAll());
+            int start = Math.min((int) pageable.getOffset(), all.size());
+            int end = Math.min(start + pageable.getPageSize(), all.size());
+            return new PageImpl<>(all.subList(start, end), pageable, all.size());
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<Owner> findOwnerByLastName(String lastName, Pageable pageable) {
+        try {
+            return ownerRepository.findByLastName(lastName, pageable);
+        } catch (UnsupportedOperationException ex) {
+            // Fallback for jdbc/jpa profiles
+            var filtered = new java.util.ArrayList<>(ownerRepository.findByLastName(lastName));
+            int start = Math.min((int) pageable.getOffset(), filtered.size());
+            int end = Math.min(start + pageable.getPageSize(), filtered.size());
+            return new PageImpl<>(filtered.subList(start, end), pageable, filtered.size());
         }
     }
 

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
@@ -492,4 +492,17 @@ class OwnerRestControllerTests {
             .andExpect(status().isNotFound());
     }
 
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void listOwners_withPagingAndSorting_returnsPage() throws Exception {
+        mockMvc.perform(get("/api/owners")
+                .param("page", "0")
+                .param("size", "5")
+                .param("sort", "lastName,desc"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").isArray())
+            .andExpect(jsonPath("$.size").value(5))
+            .andExpect(jsonPath("$.number").value(0));
+    }
+
 }


### PR DESCRIPTION
This PR introduces pagination and sorting support for the GET /owners endpoint in the Spring Petclinic REST API.

Changes Made:
	•	Updated OwnerController to accept Pageable as a parameter.
	•	Modified OwnerRepository and service layer to return Page<Owner> instead of List<Owner>.
	•	Updated JSON response to include standard Spring Data pagination metadata (pageable, totalElements,  totalPages, etc.).

Example : 
API : GET http://localhost:9966/petclinic/api/owners?page=0&size=5&sort=lastName,asc
Response : 
{
  "content": [
    { "id": 1, "firstName": "George", "lastName": "Franklin", ... }
  ],
  "pageable": {
    "pageNumber": 0,
    "pageSize": 5
  },
  "totalPages": 2,
  "totalElements": 10,
  "last": false,
  "first": true
}
