### PR TITLE
Simplify Switching between Databases

### DIFF
--- a/src/main/resources/application-h2.properties
+++ b/src/main/resources/application-h2.properties
@@ -1,9 +1,9 @@
 # H2 Database Configuration
+spring.sql.init.platform=h2
 spring.datasource.url=jdbc:h2:mem:petclinic;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
-spring.datasource.platform=h2
 
 # Hibernate Configuration
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application-hsqldb.properties
+++ b/src/main/resources/application-hsqldb.properties
@@ -1,5 +1,6 @@
 # HSQLDB config start
 #----------------------------------------------------------------
+spring.sql.init.platform=hsqldb
 spring.datasource.url=jdbc:hsqldb:mem:petclinic
 spring.datasource.username=sa
 spring.datasource.password=

--- a/src/main/resources/application-mysql.properties
+++ b/src/main/resources/application-mysql.properties
@@ -1,5 +1,5 @@
 # database init, supports mysql too
-database=mysql
+spring.sql.init.platform=mysql
 spring.datasource.url=${MYSQL_URL:jdbc:mysql://localhost/petclinic}
 spring.datasource.username=${MYSQL_USER:petclinic}
 spring.datasource.password=${MYSQL_PASS:petclinic}

--- a/src/main/resources/application-postgres.properties
+++ b/src/main/resources/application-postgres.properties
@@ -1,4 +1,4 @@
-database=postgres
+spring.sql.init.platform=postgres
 spring.datasource.url=${POSTGRES_URL:jdbc:postgresql://localhost/petclinic}
 spring.datasource.username=${POSTGRES_USER:petclinic}
 spring.datasource.password=${POSTGRES_PASS:petclinic}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,16 +1,16 @@
 # active profiles config
 #
-# application use two active profiles
+# the application uses two active profiles
 #
 # one - for select database
 # ------------------------------------------------
 # When using HSQL, use: hsqldb
 # When using MySQL, use: mysql
-# When using PostgeSQL, use: postgres
+# When using PostgreSQL, use: postgres
 # When using H2, use: h2
 # ------------------------------------------------
 #
-# one for select repository layer
+# and one for selected repository layer
 # ------------------------------------------------
 # When using Spring jpa, use: jpa
 # When using Spring JDBC, use: jdbc
@@ -24,12 +24,12 @@ spring.profiles.active=h2,spring-data-jpa
 server.port=9966
 server.servlet.context-path=/petclinic/
 
-# database init, supports hsqldb, mysql and postgres too
-database=h2
+# Default database platform; can be overridden by other profile-specific property sources 
+spring.sql.init.platform=h2
 # Ensures schema & data reload on every restart (good for local dev)
-spring.sql.init.mode=always  
-spring.sql.init.schema-locations=classpath*:db/${database}/schema.sql
-spring.sql.init.data-locations=classpath*:db/${database}/data.sql
+spring.sql.init.mode=always
+spring.sql.init.schema-locations=classpath*:db/${platform}/schema.sql
+spring.sql.init.data-locations=classpath*:db/${platform}/data.sql
 
 spring.messages.basename=messages/messages
 spring.jpa.open-in-view=false
@@ -45,6 +45,6 @@ logging.level.org.springframework=INFO
 #logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 
 # enable the desired authentication type
-# by default the authentication is disabled
+# by default, the authentication is disabled
 petclinic.security.enable=false
 


### PR DESCRIPTION
### Problem

Recent introduction of H2 database support [implied](https://github.com/spring-petclinic/spring-petclinic-rest/issues/199) the following point:

> 1. Allow opt-in for HSQLDB.
>
>    * Document how to switch between H2 and HSQLDB using profiles, so users can opt-in:
>
>    ```
>    # To use HSQLDB instead of H2:
>    spring.profiles.active=hsqldb,spring-data-jpa
>    database=hsqldb
>    ```

However, current README [contains](https://github.com/spring-petclinic/spring-petclinic-rest?tab=readme-ov-file#using-hsqldb) only this:

> * Swtich to **HSQLDB** by modifying `application.properties`:
>
>   ```
>   spring.profiles.active=hsqldb,spring-data-jpa
>   ```

If done this way, the user comes up with the following exception upon application startup:

```
...
Caused by: org.springframework.jdbc.datasource.init.ScriptStatementFailedException: Failed to execute SQL script statement #13 of file [/home/vladimir/work/source/unsorted/spring-petclinic-rest/target/classes/db/h2/schema.sql]: CREATE TABLE IF NOT EXISTS users ( username VARCHAR(20) NOT NULL PRIMARY KEY, password VARCHAR(255) NOT NULL, enabled BOOLEAN NOT NULL DEFAULT TRUE )
...
Caused by: org.hsqldb.HsqlException: unexpected token: DEFAULT
```

This is because H2-specific script gets applied to initialize the HSQLDB database.

### Solution

While looks just like a documentation issue, the problem seems to be solvable in a more user-friendly way by allowing to switch the database with only one property instead of two.

This could be achieved with proper usage of the `database` property. However, Spring Boot already [includes](https://docs.spring.io/spring-boot/how-to/data-initialization.html#howto.data-initialization.using-basic-sql-scripts) a dedicated property `spring.sql.init.platform` that can be injected into the script paths in its short form: `${platform}`.

The change allows to run the application on a different database with only one changed property (the profiles), e.g.:

```shell
./mvnw spring-boot:run -Dspring-boot.run.arguments="--spring.profiles.active=hsqldb,spring-data-jpa"
```

