### PR TITLE
Make H2 Console Available

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/security/DisableSecurityConfig.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/DisableSecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
 import org.springframework.security.web.SecurityFilterChain;
 
 /**
@@ -21,7 +22,10 @@ public class DisableSecurityConfig {
         http
             .csrf(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests((authz) -> authz
-               .anyRequest().permitAll()
+                .anyRequest().permitAll()
+            )
+            .headers((headers) -> headers
+                .frameOptions(FrameOptionsConfig::sameOrigin)  // to avoid setting of X-Frame-Options=deny header
             );
         // @formatter:on
         return http.build();


### PR DESCRIPTION
### Problem

When run on default settings, the application states in its logs that H2 Console is available at `/petclinic/h2-console` URL. However, after logging in on that page, the user sees the following:

<img width="1205" height="413" alt="Screenshot from 2025-09-22 21-39-18" src="https://github.com/user-attachments/assets/fbd64175-cc81-49a2-bf17-8f47671bab3f" />

This is due to these errors in the browser console:

```
Refused to display 'http://localhost:9966/' in a frame because it set 'X-Frame-Options' to 'deny'.
```

The reason is that not all Spring Security features are disabled when `petclinic.security.enable` is set to `false`.

### Solution

Instruct the `SecurityFilterChain` in the `DisableSecurityConfig` class to set `sameOrigin` value for `X-Frame-Options` headers.