### PR TITLE
Fix H2 SQL error in JDBC mode

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryImpl.java
@@ -15,6 +15,16 @@
  */
 package org.springframework.samples.petclinic.repository.jdbc;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
 import org.springframework.context.annotation.Profile;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -29,11 +39,6 @@ import org.springframework.samples.petclinic.model.PetType;
 import org.springframework.samples.petclinic.model.Visit;
 import org.springframework.samples.petclinic.repository.VisitRepository;
 import org.springframework.stereotype.Repository;
-
-import javax.sql.DataSource;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.*;
 
 /**
  * A simple JDBC-based implementation of the {@link VisitRepository} interface.
@@ -114,7 +119,7 @@ public class JdbcVisitRepositoryImpl implements VisitRepository {
     public Collection<Visit> findAll() throws DataAccessException {
         Map<String, Object> params = new HashMap<>();
         return this.namedParameterJdbcTemplate.query(
-            "SELECT id as visit_id, pets.id as pets_id, visit_date, description FROM visits LEFT JOIN pets ON visits.pet_id = pets.id",
+            "SELECT visits.id as visit_id, pets.id as pets_id, visit_date, description FROM visits LEFT JOIN pets ON visits.pet_id = pets.id",
             params, new JdbcVisitRowMapperExt());
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,8 +28,8 @@ server.servlet.context-path=/petclinic/
 spring.sql.init.platform=h2
 # Ensures schema & data reload on every restart (good for local dev)
 spring.sql.init.mode=always
-spring.sql.init.schema-locations=classpath*:db/${platform}/schema.sql
-spring.sql.init.data-locations=classpath*:db/${platform}/data.sql
+spring.sql.init.schema-locations=classpath*:db/${spring.sql.init.platform}/schema.sql
+spring.sql.init.data-locations=classpath*:db/${spring.sql.init.platform}/data.sql
 
 spring.messages.basename=messages/messages
 spring.jpa.open-in-view=false

--- a/src/test/java/org/springframework/samples/petclinic/service/clinicService/ClinicServiceH2JdbcTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/clinicService/ClinicServiceH2JdbcTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.service.clinicService;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * <p> Integration test using the JDBC and H2 profiles.
+ *
+ * @author Thomas Risberg
+ * @author Michael Isvy
+ * @see AbstractClinicServiceTests AbstractClinicServiceTests for more details. </p>
+ */
+@SpringBootTest
+@ActiveProfiles({"h2", "jdbc"})
+@TestPropertySource(properties = {
+    "spring.sql.init.platform=h2",
+    "spring.h2.console.enabled=false"
+})
+class ClinicServiceH2JdbcTests extends AbstractClinicServiceTests {
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/service/clinicService/ClinicServiceHsqlJdbcTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/clinicService/ClinicServiceHsqlJdbcTests.java
@@ -17,16 +17,18 @@ package org.springframework.samples.petclinic.service.clinicService;
 
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 /**
- * <p> Integration test using the jdbc profile.
+ * <p> Integration test using the JDBC and HSQLDB profiles.
  *
  * @author Thomas Risberg
  * @author Michael Isvy
  * @see AbstractClinicServiceTests AbstractClinicServiceTests for more details. </p>
  */
 @SpringBootTest
-@ActiveProfiles({"jdbc", "hsqldb"})
-class ClinicServiceJdbcTests extends AbstractClinicServiceTests {
+@ActiveProfiles({"hsqldb", "jdbc"})
+@TestPropertySource(properties = {"spring.sql.init.platform=hsqldb"})
+class ClinicServiceHsqlJdbcTests extends AbstractClinicServiceTests {
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/service/userService/UserServiceH2JdbcTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/userService/UserServiceH2JdbcTests.java
@@ -1,0 +1,15 @@
+package org.springframework.samples.petclinic.service.userService;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@ActiveProfiles({"h2", "jdbc"})
+@TestPropertySource(properties = {
+    "spring.sql.init.platform=h2",
+    "spring.h2.console.enabled=false"
+})
+class UserServiceH2JdbcTests extends AbstractUserServiceTests {
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/service/userService/UserServiceHsqlJdbcTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/userService/UserServiceHsqlJdbcTests.java
@@ -4,7 +4,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles({"jdbc", "hsqldb"})
-class UserServiceJdbcTests extends AbstractUserServiceTests {
+@ActiveProfiles({"hsqldb", "jdbc"})
+class UserServiceHsqlJdbcTests extends AbstractUserServiceTests {
 
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -25,8 +25,8 @@ server.servlet.context-path=/petclinic/
 spring.jpa.open-in-view=false
 
 # database init
-spring.sql.init.schema-locations=classpath*:db/hsqldb/schema.sql
-spring.sql.init.data-locations=classpath*:db/hsqldb/data.sql
+spring.sql.init.schema-locations=classpath*:db/${spring.sql.init.platform}/schema.sql
+spring.sql.init.data-locations=classpath*:db/${spring.sql.init.platform}/data.sql
 
 spring.messages.basename=messages/messages
 logging.level.org.springframework=INFO


### PR DESCRIPTION
### Bug Description

##### Steps to reproduce

1. Run the application on H2 database in JDBC mode:

   ```shell
   ./mvnw spring-boot:run -Dspring-boot.run.arguments="--spring.profiles.active=h2,jdbc
   ```

2. Open Swagger UI and navigate to `GET /api/visits` request

3. Execute request



##### Actual result

HTTP 500 with body:

```js
{
  "type": "http://localhost:9966/petclinic/api/visits",
  "title": "BadSqlGrammarException",
  "status": 500,
  "detail": "PreparedStatementCallback; bad SQL grammar [SELECT id as visit_id, pets.id as pets_id, visit_date, description FROM visits LEFT JOIN pets ON visits.pet_id = pets.id]",
  "instance": "/petclinic/api/visits",
  "timestamp": "2025-09-26T02:57:41.981914991Z"
}
```



##### Expected result

HTTP 200 with body:

```json
[
  {
    "date": "2013-01-01",
    "description": "rabies shot",
    "id": 1,
    "petId": 7
  },
  // ...
]
```



##### Additional info

The same exception occurs when trying to insert a new visit.



### Fix Details

The root cause is the SQL `SELECT` query in the `org.springframework.samples.petclinic.repository.jdbc.JdbcVisitRepositoryImpl#findAll` method which does not contain table name for the `id` column (aliased as `visit_id`):

```sql
SELECT id as visit_id, pets.id as pets_id, visit_date, description FROM visits LEFT JOIN pets ON visits.pet_id = pets.id
```

While works fine on HSQLDB (and possibly other DBs), this difference makes the query invalid for H2 as it cannot choose the right table between `visits` and `pets`.

The fix is to prepend the column with the table name:

```sql
SELECT visits.id as visit_id, ...
```



### Test Coverage

This regression was not detected by the integration tests because they were running on HSQLDB only. With this fix, the tests related to JDBC mode also run on H2 embedded database and now are able to detect the bug:

```
[ERROR] Errors: 
[ERROR]   ClinicServiceH2JdbcTests>AbstractClinicServiceTests.shouldFindAllVisits:234 » BadSqlGrammar PreparedStatementCallback; bad SQL grammar [SELECT id as visit_id, pets.id as pets_id, visit_date, description FROM visits LEFT JOIN pets ON visits.pet_id = pets.id]
[ERROR]   ClinicServiceH2JdbcTests>AbstractClinicServiceTests.shouldInsertVisit:244 » BadSqlGrammar PreparedStatementCallback; bad SQL grammar [SELECT id as visit_id, pets.id as pets_id, visit_date, description FROM visits LEFT JOIN pets ON visits.pet_id = pets.id]
```



### Additional Update

The automatic database platform selection recently introduced in #252 was updated to rely on the fully-qualified variable name `${spring.sql.init.platform}` (instead of just `${platform}`) as it makes the properties relations more evident and helps to avoid tricky errors on embedded database initialization.