### PR TITLE
fix: owner not exists validation addPetToOwner

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/rest/advice/ExceptionControllerAdvice.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/advice/ExceptionControllerAdvice.java
@@ -17,6 +17,9 @@
 package org.springframework.samples.petclinic.rest.advice;
 
 import jakarta.servlet.http.HttpServletRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -42,6 +45,9 @@ import java.time.Instant;
 @ControllerAdvice
 public class ExceptionControllerAdvice {
 
+    private static final Logger log =
+        LoggerFactory.getLogger(ExceptionControllerAdvice.class);
+
     /**
      * Private method for constructing the {@link ProblemDetail} object passing the name and details of the exception
      * class.
@@ -53,9 +59,12 @@ public class ExceptionControllerAdvice {
     private ProblemDetail detailBuild(Exception ex, HttpStatus status, StringBuffer url) {
         ProblemDetail detail = ProblemDetail.forStatus(status);
         detail.setType(URI.create(url.toString()));
-        detail.setTitle(ex.getClass().getSimpleName());
-        detail.setDetail(ex.getLocalizedMessage());
+        detail.setTitle(status.getReasonPhrase());
+        detail.setDetail("An unexpected error occurred.");
         detail.setProperty("timestamp", Instant.now());
+
+        log.error("Request failed. status={}, url={}, ex={}", status, url, ex.getLocalizedMessage(), ex);
+
         return detail;
     }
 

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
@@ -138,8 +138,9 @@ public class OwnerRestController implements OwnersApi {
         Pet pet = petMapper.toPet(petFieldsDto);
         Owner owner = clinicService.findOwnerById(ownerId);
 
-        if (owner == null)
-             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        if (owner == null){
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
 
         owner.setId(ownerId);
         pet.setOwner(owner);
@@ -147,7 +148,7 @@ public class OwnerRestController implements OwnersApi {
         this.clinicService.savePet(pet);
         PetDto petDto = petMapper.toPetDto(pet);
         headers.setLocation(UriComponentsBuilder.newInstance().path("/api/pets/{id}")
-                .buildAndExpand(pet.getId()).toUri());
+            .buildAndExpand(pet.getId()).toUri());
         return new ResponseEntity<>(petDto, headers, HttpStatus.CREATED);
     }
 

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
@@ -57,9 +57,9 @@ public class OwnerRestController implements OwnersApi {
     private final VisitMapper visitMapper;
 
     public OwnerRestController(ClinicService clinicService,
-                               OwnerMapper ownerMapper,
-                               PetMapper petMapper,
-                               VisitMapper visitMapper) {
+            OwnerMapper ownerMapper,
+            PetMapper petMapper,
+            VisitMapper visitMapper) {
         this.clinicService = clinicService;
         this.ownerMapper = ownerMapper;
         this.petMapper = petMapper;
@@ -99,7 +99,7 @@ public class OwnerRestController implements OwnersApi {
         this.clinicService.saveOwner(owner);
         OwnerDto ownerDto = ownerMapper.toOwnerDto(owner);
         headers.setLocation(UriComponentsBuilder.newInstance()
-            .path("/api/owners/{id}").buildAndExpand(owner.getId()).toUri());
+                .path("/api/owners/{id}").buildAndExpand(owner.getId()).toUri());
         return new ResponseEntity<>(ownerDto, headers, HttpStatus.CREATED);
     }
 
@@ -136,14 +136,18 @@ public class OwnerRestController implements OwnersApi {
     public ResponseEntity<PetDto> addPetToOwner(Integer ownerId, PetFieldsDto petFieldsDto) {
         HttpHeaders headers = new HttpHeaders();
         Pet pet = petMapper.toPet(petFieldsDto);
-        Owner owner = new Owner();
+        Owner owner = clinicService.findOwnerById(ownerId);
+
+        if (owner == null)
+             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+
         owner.setId(ownerId);
         pet.setOwner(owner);
         pet.getType().setName(null);
         this.clinicService.savePet(pet);
         PetDto petDto = petMapper.toPetDto(pet);
         headers.setLocation(UriComponentsBuilder.newInstance().path("/api/pets/{id}")
-            .buildAndExpand(pet.getId()).toUri());
+                .buildAndExpand(pet.getId()).toUri());
         return new ResponseEntity<>(petDto, headers, HttpStatus.CREATED);
     }
 
@@ -175,10 +179,9 @@ public class OwnerRestController implements OwnersApi {
         this.clinicService.saveVisit(visit);
         VisitDto visitDto = visitMapper.toVisitDto(visit);
         headers.setLocation(UriComponentsBuilder.newInstance().path("/api/visits/{id}")
-            .buildAndExpand(visit.getId()).toUri());
+                .buildAndExpand(visit.getId()).toUri());
         return new ResponseEntity<>(visitDto, headers, HttpStatus.CREATED);
     }
-
 
     @PreAuthorize("hasRole(@roles.OWNER_ADMIN)")
     @Override

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
@@ -142,7 +142,6 @@ public class OwnerRestController implements OwnersApi {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
 
-        owner.setId(ownerId);
         pet.setOwner(owner);
         pet.getType().setName(null);
         this.clinicService.savePet(pet);

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
@@ -26,6 +26,7 @@ import org.springframework.samples.petclinic.mapper.OwnerMapper;
 import org.springframework.samples.petclinic.mapper.PetMapper;
 import org.springframework.samples.petclinic.mapper.VisitMapper;
 import org.springframework.samples.petclinic.model.Owner;
+import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.rest.advice.ExceptionControllerAdvice;
 import org.springframework.samples.petclinic.rest.dto.OwnerDto;
 import org.springframework.samples.petclinic.rest.dto.PetDto;
@@ -47,7 +48,9 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -366,6 +369,26 @@ class OwnerRestControllerTests {
         this.mockMvc.perform(post("/api/owners/1/pets")
                 .content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isBadRequest()).andDo(MockMvcResultHandlers.print());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testCreatePetOwnerNotFound() throws Exception {
+        PetDto newPet = pets.get(0);
+        newPet.setId(null); // como no seu outro teste
+        ObjectMapper mapper = JsonMapper.builder()
+           .defaultDateFormat(new SimpleDateFormat("dd/MM/yyyy"))
+           .build();
+
+        String newPetAsJSON = mapper.writeValueAsString(newPet);
+        given(this.clinicService.findOwnerById(999)).willReturn(null);
+
+        this.mockMvc.perform(post("/api/owners/999/pets")
+           .content(newPetAsJSON)
+           .accept(MediaType.APPLICATION_JSON_VALUE)
+           .contentType(MediaType.APPLICATION_JSON_VALUE))
+           .andExpect(status().isNotFound())
+           .andDo(MockMvcResultHandlers.print());
     }
 
     @Test

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
@@ -375,7 +375,7 @@ class OwnerRestControllerTests {
     @WithMockUser(roles = "OWNER_ADMIN")
     void testCreatePetOwnerNotFound() throws Exception {
         PetDto newPet = pets.get(0);
-        newPet.setId(null); // como no seu outro teste
+        newPet.setId(null);
         ObjectMapper mapper = JsonMapper.builder()
            .defaultDateFormat(new SimpleDateFormat("dd/MM/yyyy"))
            .build();


### PR DESCRIPTION
This PR fixes issue #287.

The previous error handling exposed SQL and constraint details in API responses by using ex.getLocalizedMessage().

Changes:
- Replaced localized exception messages with stable API-safe messages
- Logged technical details server-side only
- Added owner existence validation before saving pets

This prevents leakage of internal persistence details while maintaining useful logging.