### PR TITLE
Fix #305: Sanitize error details and add validation tests for owner pets

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/rest/advice/ExceptionControllerAdvice.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/advice/ExceptionControllerAdvice.java
@@ -17,11 +17,12 @@
 package org.springframework.samples.petclinic.rest.advice;
 
 import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
-import org.springframework.samples.petclinic.rest.controller.BindingErrorsResponse;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -42,6 +43,11 @@ import java.time.Instant;
 @ControllerAdvice
 public class ExceptionControllerAdvice {
 
+    private static final Logger logger = LoggerFactory.getLogger(ExceptionControllerAdvice.class);
+    private static final String ERROR_UNEXPECTED = "An unexpected error occurred while processing your request";
+    private static final String ERROR_DATA_INTEGRITY = "The requested resource could not be processed due to a data constraint violation";
+    private static final String ERROR_INVALID_REQUEST = "The request contains invalid or missing parameters";
+
     /**
      * Private method for constructing the {@link ProblemDetail} object passing the name and details of the exception
      * class.
@@ -50,13 +56,13 @@ public class ExceptionControllerAdvice {
      * @param status HTTP response status.
      * @param url URL request.
      */
-    private ProblemDetail detailBuild(Exception ex, HttpStatus status, StringBuffer url) {
-        ProblemDetail detail = ProblemDetail.forStatus(status);
-        detail.setType(URI.create(url.toString()));
-        detail.setTitle(ex.getClass().getSimpleName());
-        detail.setDetail(ex.getLocalizedMessage());
-        detail.setProperty("timestamp", Instant.now());
-        return detail;
+    private ProblemDetail detailBuild(Exception ex, HttpStatus status, StringBuffer url, String detail) {
+        ProblemDetail problemDetail = ProblemDetail.forStatus(status);
+        problemDetail.setType(URI.create(url.toString()));
+        problemDetail.setTitle(ex.getClass().getSimpleName());
+        problemDetail.setDetail(detail);
+        problemDetail.setProperty("timestamp", Instant.now());
+        return problemDetail;
     }
 
     /**
@@ -69,8 +75,9 @@ public class ExceptionControllerAdvice {
     @ExceptionHandler(Exception.class)
     @ResponseBody
     public ResponseEntity<ProblemDetail> handleGeneralException(Exception e, HttpServletRequest request) {
+        logger.error("Unexpected error occurred", e);
         HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
-        ProblemDetail detail = this.detailBuild(e, status, request.getRequestURL());
+        ProblemDetail detail = this.detailBuild(e, status, request.getRequestURL(), ERROR_UNEXPECTED);
         return ResponseEntity.status(status).body(detail);
     }
 
@@ -78,38 +85,34 @@ public class ExceptionControllerAdvice {
      * Handles {@link DataIntegrityViolationException} which typically indicates database constraint violations. This
      * method returns a 404 Not Found status if an entity does not exist.
      *
-     * @param ex The {@link DataIntegrityViolationException} to be handled
+     * @param e The {@link DataIntegrityViolationException} to be handled
      * @param request {@link HttpServletRequest} object referring to the current request.
      * @return A {@link ResponseEntity} containing the error information and a 404 Not Found status
      */
     @ExceptionHandler(DataIntegrityViolationException.class)
     @ResponseBody
-    public ResponseEntity<ProblemDetail> handleDataIntegrityViolationException(DataIntegrityViolationException ex, HttpServletRequest request) {
+    public ResponseEntity<ProblemDetail> handleDataIntegrityViolationException(DataIntegrityViolationException e, HttpServletRequest request) {
+        logger.error("Data integrity violation: {}", e.getMessage());
         HttpStatus status = HttpStatus.NOT_FOUND;
-        ProblemDetail detail = ProblemDetail.forStatus(status);
-        detail.setType(URI.create(request.getRequestURL().toString()));
-        detail.setTitle(ex.getClass().getSimpleName());
-        detail.setDetail("Request could not be processed");
-        detail.setProperty("timestamp", Instant.now());
+        ProblemDetail detail = this.detailBuild(e, status, request.getRequestURL(), ERROR_DATA_INTEGRITY);
         return ResponseEntity.status(status).body(detail);
     }
 
     /**
      * Handles exception thrown by Bean Validation on controller methods parameters
      *
-     * @param ex The {@link MethodArgumentNotValidException} to be handled
+     * @param e The {@link MethodArgumentNotValidException} to be handled
      * @param request {@link HttpServletRequest} object referring to the current request.
      * @return A {@link ResponseEntity} containing the error information and a 400 Bad Request status.
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseBody
-    public ResponseEntity<ProblemDetail> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex, HttpServletRequest request) {
+    public ResponseEntity<ProblemDetail> handleMethodArgumentNotValidException(MethodArgumentNotValidException e, HttpServletRequest request) {
         HttpStatus status = HttpStatus.BAD_REQUEST;
-        BindingErrorsResponse errors = new BindingErrorsResponse();
-        BindingResult bindingResult = ex.getBindingResult();
+        BindingResult bindingResult = e.getBindingResult();
         if (bindingResult.hasErrors()) {
-            errors.addAllErrors(bindingResult);
-            ProblemDetail detail = this.detailBuild(ex, status, request.getRequestURL());
+            logger.error("Invalid request: {}", bindingResult.getAllErrors());
+            ProblemDetail detail = this.detailBuild(e, status, request.getRequestURL(), ERROR_INVALID_REQUEST);
             return ResponseEntity.status(status).body(detail);
         }
         return ResponseEntity.status(status).build();

--- a/src/main/java/org/springframework/samples/petclinic/rest/advice/ExceptionControllerAdvice.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/advice/ExceptionControllerAdvice.java
@@ -23,6 +23,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.samples.petclinic.rest.controller.BindingErrorsResponse;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -109,8 +110,10 @@ public class ExceptionControllerAdvice {
     @ResponseBody
     public ResponseEntity<ProblemDetail> handleMethodArgumentNotValidException(MethodArgumentNotValidException e, HttpServletRequest request) {
         HttpStatus status = HttpStatus.BAD_REQUEST;
+        BindingErrorsResponse errors = new BindingErrorsResponse();
         BindingResult bindingResult = e.getBindingResult();
         if (bindingResult.hasErrors()) {
+            errors.addAllErrors(bindingResult);
             logger.error("Invalid request: {}", bindingResult.getAllErrors());
             ProblemDetail detail = this.detailBuild(e, status, request.getRequestURL(), ERROR_INVALID_REQUEST);
             return ResponseEntity.status(status).body(detail);

--- a/src/main/java/org/springframework/samples/petclinic/rest/advice/ExceptionControllerAdvice.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/advice/ExceptionControllerAdvice.java
@@ -31,7 +31,10 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.net.URI;
+import java.util.List;
+import java.util.Map;
 import java.time.Instant;
+import java.util.Objects;
 
 /**
  * Global Exception handler for REST controllers.
@@ -53,16 +56,17 @@ public class ExceptionControllerAdvice {
      * Private method for constructing the {@link ProblemDetail} object passing the name and details of the exception
      * class.
      *
-     * @param ex     Object referring to the thrown exception.
+     * @param e     Object referring to the thrown exception.
      * @param status HTTP response status.
      * @param url URL request.
      */
-    private ProblemDetail detailBuild(Exception ex, HttpStatus status, StringBuffer url, String detail) {
+    private ProblemDetail detailBuild(Exception e, HttpStatus status, StringBuffer url, String detail) {
         ProblemDetail problemDetail = ProblemDetail.forStatus(status);
         problemDetail.setType(URI.create(url.toString()));
-        problemDetail.setTitle(ex.getClass().getSimpleName());
+        problemDetail.setTitle(e.getClass().getSimpleName());
         problemDetail.setDetail(detail);
         problemDetail.setProperty("timestamp", Instant.now());
+        problemDetail.setProperty("schemaValidationErrors", List.of());
         return problemDetail;
     }
 
@@ -76,7 +80,7 @@ public class ExceptionControllerAdvice {
     @ExceptionHandler(Exception.class)
     @ResponseBody
     public ResponseEntity<ProblemDetail> handleGeneralException(Exception e, HttpServletRequest request) {
-        logger.error("Unexpected error occurred", e);
+        logger.error("Unexpected error at {} {}", request.getMethod(), request.getRequestURI(), e);
         HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
         ProblemDetail detail = this.detailBuild(e, status, request.getRequestURL(), ERROR_UNEXPECTED);
         return ResponseEntity.status(status).body(detail);
@@ -93,7 +97,11 @@ public class ExceptionControllerAdvice {
     @ExceptionHandler(DataIntegrityViolationException.class)
     @ResponseBody
     public ResponseEntity<ProblemDetail> handleDataIntegrityViolationException(DataIntegrityViolationException e, HttpServletRequest request) {
-        logger.error("Data integrity violation: {}", e.getMessage());
+        logger.warn("Data integrity violation at {} {}: {}",
+            request.getMethod(),
+            request.getRequestURI(),
+            e.getMessage());
+        logger.debug("Data integrity violation stacktrace", e);
         HttpStatus status = HttpStatus.NOT_FOUND;
         ProblemDetail detail = this.detailBuild(e, status, request.getRequestURL(), ERROR_DATA_INTEGRITY);
         return ResponseEntity.status(status).body(detail);
@@ -112,13 +120,27 @@ public class ExceptionControllerAdvice {
         HttpStatus status = HttpStatus.BAD_REQUEST;
         BindingErrorsResponse errors = new BindingErrorsResponse();
         BindingResult bindingResult = e.getBindingResult();
+        ProblemDetail detail = this.detailBuild(e, status, request.getRequestURL(), ERROR_INVALID_REQUEST);
         if (bindingResult.hasErrors()) {
             errors.addAllErrors(bindingResult);
-            logger.error("Invalid request: {}", bindingResult.getAllErrors());
-            ProblemDetail detail = this.detailBuild(e, status, request.getRequestURL(), ERROR_INVALID_REQUEST);
+            List<Map<String, String>> schemaValidationErrors = bindingResult.getFieldErrors().stream()
+                .map(fieldError -> Map.of(
+                    "field", fieldError.getField(),
+                    "rejectedValue", Objects.toString(fieldError.getRejectedValue(), "null"),
+                    "defaultMessage", Objects.toString(fieldError.getDefaultMessage(), "Validation failed"),
+                    "message", "Field '%s' %s (rejected value: %s)".formatted(
+                        fieldError.getField(),
+                        Objects.toString(fieldError.getDefaultMessage(), "Validation failed"),
+                        Objects.toString(fieldError.getRejectedValue(), "null"))))
+                .toList();
+            logger.debug("Validation error at {} {}: {}",
+                request.getMethod(),
+                request.getRequestURI(),
+                bindingResult.getFieldErrors());
+            detail.setProperty("schemaValidationErrors", schemaValidationErrors);
             return ResponseEntity.status(status).body(detail);
         }
-        return ResponseEntity.status(status).build();
+        return ResponseEntity.status(status).body(detail);
     }
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/rest/advice/ExceptionControllerAdvice.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/advice/ExceptionControllerAdvice.java
@@ -16,6 +16,11 @@
 
 package org.springframework.samples.petclinic.rest.advice;
 
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,17 +29,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.samples.petclinic.rest.controller.BindingErrorsResponse;
+import org.springframework.samples.petclinic.rest.dto.ValidationMessageDto;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
-
-import java.net.URI;
-import java.util.List;
-import java.util.Map;
-import java.time.Instant;
-import java.util.Objects;
 
 /**
  * Global Exception handler for REST controllers.
@@ -66,7 +66,7 @@ public class ExceptionControllerAdvice {
         problemDetail.setTitle(e.getClass().getSimpleName());
         problemDetail.setDetail(detail);
         problemDetail.setProperty("timestamp", Instant.now());
-        problemDetail.setProperty("schemaValidationErrors", List.of());
+        problemDetail.setProperty("schemaValidationErrors", List.<ValidationMessageDto>of());
         return problemDetail;
     }
 
@@ -123,15 +123,19 @@ public class ExceptionControllerAdvice {
         ProblemDetail detail = this.detailBuild(e, status, request.getRequestURL(), ERROR_INVALID_REQUEST);
         if (bindingResult.hasErrors()) {
             errors.addAllErrors(bindingResult);
-            List<Map<String, String>> schemaValidationErrors = bindingResult.getFieldErrors().stream()
-                .map(fieldError -> Map.of(
-                    "field", fieldError.getField(),
-                    "rejectedValue", Objects.toString(fieldError.getRejectedValue(), "null"),
-                    "defaultMessage", Objects.toString(fieldError.getDefaultMessage(), "Validation failed"),
-                    "message", "Field '%s' %s (rejected value: %s)".formatted(
+            List<ValidationMessageDto> schemaValidationErrors = bindingResult.getFieldErrors().stream()
+                .map(fieldError -> {
+                    String rejectedValue = Objects.toString(fieldError.getRejectedValue(), "null");
+                    String defaultMessage = Objects.toString(fieldError.getDefaultMessage(), "Validation failed");
+                    String message = "Field '%s' %s (rejected value: %s)".formatted(
                         fieldError.getField(),
-                        Objects.toString(fieldError.getDefaultMessage(), "Validation failed"),
-                        Objects.toString(fieldError.getRejectedValue(), "null"))))
+                        defaultMessage,
+                        rejectedValue);
+                    return new ValidationMessageDto(message)
+                        .putAdditionalProperty("field", fieldError.getField())
+                        .putAdditionalProperty("rejectedValue", rejectedValue)
+                        .putAdditionalProperty("defaultMessage", defaultMessage);
+                })
                 .toList();
             logger.debug("Validation error at {} {}: {}",
                 request.getMethod(),

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
@@ -488,10 +488,10 @@ class OwnerRestControllerTests {
     @Test
     @WithMockUser(roles = "OWNER_ADMIN")
     void testCreateOwnerWithUnexpectedErrorShouldReturnInternalServerErrorWithGenericDetail() throws Exception {
-        OwnerDto newOwnwerDto = owners.get(0);
-        newOwnwerDto.setId(null);
+        OwnerDto newOwnerDto = owners.get(0);
+        newOwnerDto.setId(null);
         ObjectMapper mapper = new ObjectMapper();
-        String newOwnerAsJSON = mapper.writeValueAsString(newOwnwerDto);
+        String newOwnerAsJSON = mapper.writeValueAsString(newOwnerDto);
         doThrow(new RuntimeException("Low-level persistence exception details"))
             .when(this.clinicService).saveOwner(any());
         this.mockMvc.perform(post("/api/owners")

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
@@ -423,10 +423,14 @@ class OwnerRestControllerTests {
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.detail").value("The request contains invalid or missing parameters"))
             .andExpect(jsonPath("$.title").value("MethodArgumentNotValidException"))
-            .andExpect(jsonPath("$.schemaValidationErrors").doesNotExist());
+            .andExpect(jsonPath("$.schemaValidationErrors").isArray())
+            .andExpect(jsonPath("$.schemaValidationErrors[0].message").exists())
+            .andExpect(jsonPath("$.schemaValidationErrors[0].field").exists())
+            .andExpect(jsonPath("$.schemaValidationErrors[0].rejectedValue").exists())
+            .andExpect(jsonPath("$.schemaValidationErrors[0].defaultMessage").exists());
     }
 
-        @Test
+    @Test
     @WithMockUser(roles = "OWNER_ADMIN")
     void testCreatePetWithEmptyTypeNameShouldReturnBadRequestWithGenericDetail() throws Exception {
         PetDto newPet = pets.get(0);
@@ -442,7 +446,11 @@ class OwnerRestControllerTests {
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.detail").value("The request contains invalid or missing parameters"))
             .andExpect(jsonPath("$.title").value("MethodArgumentNotValidException"))
-            .andExpect(jsonPath("$.schemaValidationErrors").doesNotExist());
+            .andExpect(jsonPath("$.schemaValidationErrors").isArray())
+            .andExpect(jsonPath("$.schemaValidationErrors[0].message").exists())
+            .andExpect(jsonPath("$.schemaValidationErrors[0].field").exists())
+            .andExpect(jsonPath("$.schemaValidationErrors[0].rejectedValue").exists())
+            .andExpect(jsonPath("$.schemaValidationErrors[0].defaultMessage").exists());
     }
 
     @Test
@@ -461,7 +469,11 @@ class OwnerRestControllerTests {
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.detail").value("The request contains invalid or missing parameters"))
             .andExpect(jsonPath("$.title").value("MethodArgumentNotValidException"))
-            .andExpect(jsonPath("$.schemaValidationErrors").doesNotExist());
+            .andExpect(jsonPath("$.schemaValidationErrors").isArray())
+            .andExpect(jsonPath("$.schemaValidationErrors[0].message").exists())
+            .andExpect(jsonPath("$.schemaValidationErrors[0].field").exists())
+            .andExpect(jsonPath("$.schemaValidationErrors[0].rejectedValue").exists())
+            .andExpect(jsonPath("$.schemaValidationErrors[0].defaultMessage").exists());
     }
 
     @Test

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
@@ -466,6 +466,45 @@ class OwnerRestControllerTests {
 
     @Test
     @WithMockUser(roles = "OWNER_ADMIN")
+    void testCreatePetWithUnexpectedErrorShouldReturnInternalServerErrorWithGenericDetail() throws Exception {
+        PetDto newPet = pets.get(0);
+        newPet.setId(null);
+        ObjectMapper mapper = JsonMapper.builder()
+            .defaultDateFormat(new SimpleDateFormat("dd/MM/yyyy"))
+            .build();
+        String newPetAsJSON = mapper.writeValueAsString(newPet);
+        given(this.clinicService.findOwnerById(1)).willReturn(ownerMapper.toOwner(owners.get(0)));
+        doThrow(new IllegalStateException("JDBC timeout while executing insert into pets"))
+            .when(this.clinicService).savePet(any());
+        this.mockMvc.perform(post("/api/owners/1/pets")
+                .content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isInternalServerError())
+            .andExpect(jsonPath("$.detail").value("An unexpected error occurred while processing your request"))
+            .andExpect(jsonPath("$.title").value("IllegalStateException"))
+            .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testCreateOwnerWithUnexpectedErrorShouldReturnInternalServerErrorWithGenericDetail() throws Exception {
+        OwnerDto newOwnwerDto = owners.get(0);
+        newOwnwerDto.setId(null);
+        ObjectMapper mapper = new ObjectMapper();
+        String newOwnerAsJSON = mapper.writeValueAsString(newOwnwerDto);
+        doThrow(new RuntimeException("Low-level persistence exception details"))
+            .when(this.clinicService).saveOwner(any());
+        this.mockMvc.perform(post("/api/owners")
+                .content(newOwnerAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isInternalServerError())
+            .andExpect(jsonPath("$.detail").value("An unexpected error occurred while processing your request"))
+            .andExpect(jsonPath("$.title").value("RuntimeException"))
+            .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
     void testCreateVisitSuccess() throws Exception {
         VisitDto newVisit = visits.get(0);
         newVisit.setId(999);

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
@@ -389,7 +389,7 @@ class OwnerRestControllerTests {
                 .content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
             .andDo(MockMvcResultHandlers.print())
             .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.detail").value("Request could not be processed"));
+            .andExpect(jsonPath("$.detail").value("The requested resource could not be processed due to a data constraint violation"));
     }
 
     @Test
@@ -405,6 +405,63 @@ class OwnerRestControllerTests {
         this.mockMvc.perform(post("/api/owners/1000000/pets")
                 .content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testCreatePetWithNullTypeShouldReturnBadRequestWithGenericDetail() throws Exception {
+        PetDto newPet = pets.get(0);
+        newPet.setId(null);
+        newPet.setType(null);
+        ObjectMapper mapper = JsonMapper.builder()
+            .defaultDateFormat(new SimpleDateFormat("dd/MM/yyyy"))
+            .build();
+        String newPetAsJSON = mapper.writeValueAsString(newPet);
+        this.mockMvc.perform(post("/api/owners/1/pets")
+                .content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.detail").value("The request contains invalid or missing parameters"))
+            .andExpect(jsonPath("$.title").value("MethodArgumentNotValidException"))
+            .andExpect(jsonPath("$.schemaValidationErrors").doesNotExist());
+    }
+
+        @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testCreatePetWithEmptyTypeNameShouldReturnBadRequestWithGenericDetail() throws Exception {
+        PetDto newPet = pets.get(0);
+        newPet.setId(null);
+        newPet.getType().setName("");
+        ObjectMapper mapper = JsonMapper.builder()
+            .defaultDateFormat(new SimpleDateFormat("dd/MM/yyyy"))
+            .build();
+        String newPetAsJSON = mapper.writeValueAsString(newPet);
+        this.mockMvc.perform(post("/api/owners/1/pets")
+                .content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.detail").value("The request contains invalid or missing parameters"))
+            .andExpect(jsonPath("$.title").value("MethodArgumentNotValidException"))
+            .andExpect(jsonPath("$.schemaValidationErrors").doesNotExist());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testCreatePetWithNullTypeIdShouldReturnBadRequestWithGenericDetail() throws Exception {
+        PetDto newPet = pets.get(0);
+        newPet.setId(null);
+        newPet.getType().setId(null);
+        ObjectMapper mapper = JsonMapper.builder()
+            .defaultDateFormat(new SimpleDateFormat("dd/MM/yyyy"))
+            .build();
+        String newPetAsJSON = mapper.writeValueAsString(newPet);
+        this.mockMvc.perform(post("/api/owners/1/pets")
+                .content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.detail").value("The request contains invalid or missing parameters"))
+            .andExpect(jsonPath("$.title").value("MethodArgumentNotValidException"))
+            .andExpect(jsonPath("$.schemaValidationErrors").doesNotExist());
     }
 
     @Test


### PR DESCRIPTION
This PR fixes #305.

I updated the global exception handling, so API errors are more consistent and don’t expose internal technical details.

### What changed
- The `ExceptionControllerAdvice` has been updated. It now provides generic, safe messages when unexpected errors occur, when requests are invalid, or when data integrity issues are detected.
- `ProblemDetail` now always includes `schemaValidationErrors` (empty by default).
- For validation failures (`MethodArgumentNotValidException`), `schemaValidationErrors` is populated from `BindingResult`.
- Added logging so backend troubleshooting is still possible without leaking details to clients.

### Why this change
OpenAPI currently defines `schemaValidationErrors` in `ProblemDetail`, so this PR aligns runtime behavior with that contract while keeping messages client-safe and non-technical.

### Tests
- Updated `OwnerRestControllerTests` to match the new error format.
- Added/updated tests to verify:
  - generic error details are returned
  - technical/sensitive exception details are not exposed
  - `schemaValidationErrors` is present for validation errors

Feedback is welcome if you think something should be adjusted or improved.