### PR TITLE
fix: validate owner-pet relationship in update endpoint

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
@@ -18,6 +18,7 @@ package org.springframework.samples.petclinic.rest.controller;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -159,7 +160,9 @@ public class OwnerRestController implements OwnersApi {
     @Override
     public ResponseEntity<Void> updateOwnersPet(Integer ownerId, Integer petId, PetFieldsDto petFieldsDto) {
         Owner currentOwner = this.clinicService.findOwnerById(ownerId);
-        if (currentOwner != null) {
+        if (currentOwner != null
+            && currentOwner.getPets().stream().anyMatch((pet -> Objects.equals(pet.getId(), petId)))
+        ) {
             Pet currentPet = this.clinicService.findPetById(petId);
             if (currentPet != null) {
                 currentPet.setBirthDate(petFieldsDto.getBirthDate());

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
@@ -459,7 +459,7 @@ class OwnerRestControllerTests {
     @WithMockUser(roles = "OWNER_ADMIN")
     void testUpdateOwnersPetSuccess() throws Exception {
         int ownerId = owners.get(0).getId();
-        int petId = pets.get(0).getId();
+        int petId = owners.get(0).getPets().get(0).getId();
         given(this.clinicService.findOwnerById(ownerId)).willReturn(ownerMapper.toOwner(owners.get(0)));
         given(this.clinicService.findPetById(petId)).willReturn(petMapper.toPet(pets.get(0)));
         PetDto updatedPetDto = pets.get(0);


### PR DESCRIPTION
Fixes #310

The endpoint PUT /owners/{ownerId}/pets/{petId} allowed updating pets that do not belong to the specified owner.

This PR adds validation to ensure that the pet being updated belongs to the given owner:

```
if (currentOwner != null &&
    currentOwner.getPets().stream().anyMatch(pet -> Objects.equals(pet.getId(), petId))) {
    ...
}
```

This approach keeps the `service` and `repository` layers unchanged and introduces a minimal fix at the controller level.

An alternative approach could be to validate ownership at the repository level using a method like `findPetByIdAndOwnerId`, but the current solution avoids additional changes and resolves the issue effectively.