### PR TITLE
Add pagination support for listing owners via REST API

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/mapper/OwnerMapper.java
+++ b/src/main/java/org/springframework/samples/petclinic/mapper/OwnerMapper.java
@@ -1,10 +1,13 @@
 package org.springframework.samples.petclinic.mapper;
 
+import org.jspecify.annotations.NonNull;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.springframework.data.domain.Page;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.rest.dto.OwnerDto;
 import org.springframework.samples.petclinic.rest.dto.OwnerFieldsDto;
+import org.springframework.samples.petclinic.rest.dto.OwnerPageDto;
 
 import java.util.Collection;
 import java.util.List;
@@ -26,4 +29,14 @@ public interface OwnerMapper {
     List<OwnerDto> toOwnerDtoCollection(Collection<Owner> ownerCollection);
 
     Collection<Owner> toOwners(Collection<OwnerDto> ownerDtos);
+
+    default OwnerPageDto toOwnerPageDto(@NonNull Page<Owner> ownerPage) {
+        OwnerPageDto ownerPageDto = new OwnerPageDto();
+        ownerPageDto.setContent(toOwnerDtoCollection(ownerPage.getContent()));
+        ownerPageDto.setPage(ownerPage.getNumber());
+        ownerPageDto.setSize(ownerPage.getSize());
+        ownerPageDto.setTotalElements(ownerPage.getTotalElements());
+        ownerPageDto.setTotalPages(ownerPage.getTotalPages());
+        return ownerPageDto;
+    }
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/OwnerRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/OwnerRepository.java
@@ -18,6 +18,8 @@ package org.springframework.samples.petclinic.repository;
 import java.util.Collection;
 
 import org.springframework.dao.DataAccessException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.samples.petclinic.model.BaseEntity;
 import org.springframework.samples.petclinic.model.Owner;
 
@@ -42,6 +44,8 @@ public interface OwnerRepository {
      * found)
      */
     Collection<Owner> findByLastName(String lastName) throws DataAccessException;
+
+    Page<Owner> findByLastName(String lastName, Pageable pageable) throws DataAccessException;
 
     /**
      * Retrieve an <code>Owner</code> from the data store by id.
@@ -68,6 +72,8 @@ public interface OwnerRepository {
      * found)
      */
 	Collection<Owner> findAll() throws DataAccessException;
+
+    Page<Owner> findAll(Pageable pageable) throws DataAccessException;
 	
     /**
      * Delete an <code>Owner</code> to the data store by <code>Owner</code>.

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryImpl.java
@@ -18,6 +18,9 @@ import org.springframework.boot.sql.init.dependency.DependsOnDatabaseInitializat
 import org.springframework.context.annotation.Profile;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -86,6 +89,26 @@ public class JdbcOwnerRepositoryImpl implements OwnerRepository {
         );
         loadOwnersPetsAndVisits(owners);
         return owners;
+    }
+
+    @Override
+    public Page<Owner> findByLastName(String lastName, Pageable pageable) throws DataAccessException {
+        Map<String, Object> params = new HashMap<>();
+        params.put("lastName", lastName + "%");
+        params.put("size", pageable.getPageSize());
+        params.put("offset", pageable.getOffset());
+        List<Owner> owners = this.namedParameterJdbcTemplate.query(
+            "SELECT id, first_name, last_name, address, city, telephone FROM owners WHERE last_name like :lastName ORDER BY id LIMIT :size OFFSET :offset",
+            params,
+            BeanPropertyRowMapper.newInstance(Owner.class)
+        );
+        loadOwnersPetsAndVisits(owners);
+        Long total = this.namedParameterJdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM owners WHERE last_name like :lastName",
+            params,
+            Long.class
+        );
+        return new PageImpl<>(owners, pageable, total == null ? 0 : total);
     }
 
     /**
@@ -168,6 +191,24 @@ public class JdbcOwnerRepositoryImpl implements OwnerRepository {
         }
 	    return owners;
 	}
+
+    @Override
+    public Page<Owner> findAll(Pageable pageable) throws DataAccessException {
+        Map<String, Object> params = new HashMap<>();
+        params.put("size", pageable.getPageSize());
+        params.put("offset", pageable.getOffset());
+        List<Owner> owners = this.namedParameterJdbcTemplate.query(
+            "SELECT id, first_name, last_name, address, city, telephone FROM owners ORDER BY id LIMIT :size OFFSET :offset",
+            params,
+            BeanPropertyRowMapper.newInstance(Owner.class));
+        loadOwnersPetsAndVisits(owners);
+        Long total = this.namedParameterJdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM owners",
+            params,
+            Long.class
+        );
+        return new PageImpl<>(owners, pageable, total == null ? 0 : total);
+    }
 
 	@Override
 	@Transactional

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaOwnerRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaOwnerRepositoryImpl.java
@@ -16,13 +16,18 @@
 package org.springframework.samples.petclinic.repository.jpa;
 
 import java.util.Collection;
+import java.util.List;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Query;
 
+import org.jspecify.annotations.NonNull;
 import org.springframework.context.annotation.Profile;
 import org.springframework.dao.DataAccessException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.repository.OwnerRepository;
 import org.springframework.stereotype.Repository;
@@ -61,6 +66,20 @@ public class JpaOwnerRepositoryImpl implements OwnerRepository {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
+    public Page<Owner> findByLastName(String lastName, Pageable pageable) throws DataAccessException {
+        Query query = this.em.createQuery("SELECT owner FROM Owner owner WHERE owner.lastName LIKE :lastName ORDER BY owner.id");
+        query.setParameter("lastName", lastName + "%");
+        query.setFirstResult((int) pageable.getOffset());
+        query.setMaxResults(pageable.getPageSize());
+        List<Owner> owners = query.getResultList();
+        Query countQuery = this.em.createQuery("SELECT COUNT(owner) FROM Owner owner WHERE owner.lastName LIKE :lastName");
+        countQuery.setParameter("lastName", lastName + "%");
+        long total = (long) countQuery.getSingleResult();
+        return new PageImpl<>(owners, pageable, total);
+    }
+
+    @Override
     public Owner findById(int id) {
         // using 'join fetch' because a single query should load both owners and pets
         // using 'left join fetch' because it might happen that an owner does not have pets yet
@@ -86,6 +105,18 @@ public class JpaOwnerRepositoryImpl implements OwnerRepository {
 		Query query = this.em.createQuery("SELECT owner FROM Owner owner");
         return query.getResultList();
 	}
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Page<Owner> findAll(@NonNull Pageable pageable) throws DataAccessException {
+        Query query = this.em.createQuery("SELECT owner FROM Owner owner ORDER BY owner.id");
+        query.setFirstResult((int) pageable.getOffset());
+        query.setMaxResults(pageable.getPageSize());
+        List<Owner> owners = query.getResultList();
+        Query countQuery = this.em.createQuery("SELECT COUNT(owner) FROM Owner owner");
+        long total = (long) countQuery.getSingleResult();
+        return new PageImpl<>(owners, pageable, total);
+    }
 
 	@Override
 	public void delete(Owner owner) throws DataAccessException {

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataOwnerRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataOwnerRepository.java
@@ -18,6 +18,8 @@ package org.springframework.samples.petclinic.repository.springdatajpa;
 import java.util.Collection;
 
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
@@ -37,6 +39,18 @@ public interface SpringDataOwnerRepository extends OwnerRepository, Repository<O
     @Override
     @Query("SELECT DISTINCT owner FROM Owner owner left join fetch owner.pets WHERE owner.lastName LIKE :lastName%")
     Collection<Owner> findByLastName(@Param("lastName") String lastName);
+
+    @Override
+    @Query(
+        value = "SELECT owner FROM Owner owner WHERE owner.lastName LIKE CONCAT(:lastName, '%')",
+        countQuery = "SELECT COUNT(owner) FROM Owner owner WHERE owner.lastName LIKE CONCAT(:lastName, '%')")
+    Page<Owner> findByLastName(@Param("lastName") String lastName, Pageable pageable);
+
+    @Override
+    @Query(
+        value = "SELECT owner FROM Owner owner",
+        countQuery = "SELECT COUNT(owner) FROM Owner owner")
+    Page<Owner> findAll(Pageable pageable);
 
     @Override
     @Query("SELECT owner FROM Owner owner left join fetch owner.pets WHERE owner.id =:id")

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
@@ -18,7 +18,11 @@ package org.springframework.samples.petclinic.rest.controller;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -29,8 +33,10 @@ import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.model.Visit;
 import org.springframework.samples.petclinic.rest.api.OwnersApi;
+import org.springframework.samples.petclinic.rest.api.V2Api;
 import org.springframework.samples.petclinic.rest.dto.OwnerDto;
 import org.springframework.samples.petclinic.rest.dto.OwnerFieldsDto;
+import org.springframework.samples.petclinic.rest.dto.OwnerPageDto;
 import org.springframework.samples.petclinic.rest.dto.PetDto;
 import org.springframework.samples.petclinic.rest.dto.PetFieldsDto;
 import org.springframework.samples.petclinic.rest.dto.VisitDto;
@@ -40,6 +46,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import jakarta.transaction.Transactional;
@@ -51,7 +58,7 @@ import jakarta.transaction.Transactional;
 @RestController
 @CrossOrigin(exposedHeaders = "errors, content-type")
 @RequestMapping("/api")
-public class OwnerRestController implements OwnersApi {
+public class OwnerRestController implements OwnersApi, V2Api {
 
     private final ClinicService clinicService;
 
@@ -71,6 +78,11 @@ public class OwnerRestController implements OwnersApi {
         this.visitMapper = visitMapper;
     }
 
+    @Override
+    public Optional<NativeWebRequest> getRequest() {
+        return Optional.empty();
+    }
+
     @PreAuthorize("hasRole(@roles.OWNER_ADMIN)")
     @Override
     public ResponseEntity<List<OwnerDto>> listOwners(String lastName) {
@@ -84,6 +96,27 @@ public class OwnerRestController implements OwnersApi {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
         return new ResponseEntity<>(ownerMapper.toOwnerDtoCollection(owners), HttpStatus.OK);
+    }
+
+    @PreAuthorize("hasRole(@roles.OWNER_ADMIN)")
+    @Override
+    public ResponseEntity<OwnerPageDto> listOwnersPage(String lastName, Integer page, Integer size) {
+        int pageNumber = page == null ? 0 : page;
+        int pageSize = size == null ? 20 : size;
+        Page<Owner> owners = this.clinicService.findOwners(
+            lastName,
+            PageRequest.of(pageNumber, pageSize, Sort.by("id")));
+        return new ResponseEntity<>(toOwnerPageDto(owners), HttpStatus.OK);
+    }
+
+    private OwnerPageDto toOwnerPageDto(Page<Owner> owners) {
+        OwnerPageDto ownerPageDto = new OwnerPageDto();
+        ownerPageDto.setContent(ownerMapper.toOwnerDtoCollection(owners.getContent()));
+        ownerPageDto.setPage(owners.getNumber());
+        ownerPageDto.setSize(owners.getSize());
+        ownerPageDto.setTotalElements(owners.getTotalElements());
+        ownerPageDto.setTotalPages(owners.getTotalPages());
+        return ownerPageDto;
     }
 
     @PreAuthorize("hasRole(@roles.OWNER_ADMIN)")

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
@@ -106,17 +106,7 @@ public class OwnerRestController implements OwnersApi, V2Api {
         Page<Owner> owners = this.clinicService.findOwners(
             lastName,
             PageRequest.of(pageNumber, pageSize, Sort.by("id")));
-        return new ResponseEntity<>(toOwnerPageDto(owners), HttpStatus.OK);
-    }
-
-    private OwnerPageDto toOwnerPageDto(Page<Owner> owners) {
-        OwnerPageDto ownerPageDto = new OwnerPageDto();
-        ownerPageDto.setContent(ownerMapper.toOwnerDtoCollection(owners.getContent()));
-        ownerPageDto.setPage(owners.getNumber());
-        ownerPageDto.setSize(owners.getSize());
-        ownerPageDto.setTotalElements(owners.getTotalElements());
-        ownerPageDto.setTotalPages(owners.getTotalPages());
-        return ownerPageDto;
+        return new ResponseEntity<>(ownerMapper.toOwnerPageDto(owners), HttpStatus.OK);
     }
 
     @PreAuthorize("hasRole(@roles.OWNER_ADMIN)")

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicService.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicService.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.springframework.dao.DataAccessException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.model.PetType;
@@ -52,6 +54,7 @@ public interface ClinicService {
 	void deleteVet(Vet vet) throws DataAccessException;
 	Owner findOwnerById(int id) throws DataAccessException;
 	Collection<Owner> findAllOwners() throws DataAccessException;
+	Page<Owner> findOwners(String lastName, Pageable pageable) throws DataAccessException;
 	void saveOwner(Owner owner) throws DataAccessException;
 	void deleteOwner(Owner owner) throws DataAccessException;
 	Collection<Owner> findOwnerByLastName(String lastName) throws DataAccessException;

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
@@ -17,6 +17,8 @@ package org.springframework.samples.petclinic.service;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.orm.ObjectRetrievalFailureException;
 import org.springframework.samples.petclinic.model.*;
 import org.springframework.samples.petclinic.repository.*;
@@ -118,6 +120,15 @@ public class ClinicServiceImpl implements ClinicService {
     @Transactional(readOnly = true)
     public Collection<Owner> findAllOwners() throws DataAccessException {
         return ownerRepository.findAll();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<Owner> findOwners(String lastName, Pageable pageable) throws DataAccessException {
+        if (lastName != null) {
+            return ownerRepository.findByLastName(lastName, pageable);
+        }
+        return ownerRepository.findAll(pageable);
     }
 
     @Override

--- a/src/main/resources/openapi.yml
+++ b/src/main/resources/openapi.yml
@@ -132,6 +132,73 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
+  /v2/owners:
+    get:
+      tags:
+        - owner
+      operationId: listOwnersPage
+      summary: Lists pet owners with pagination
+      description: Returns a page of pet owners.
+      parameters:
+        - name: lastName
+          in: query
+          description: Last name.
+          required: false
+          schema:
+            type: string
+            example: Davis
+        - name: page
+          in: query
+          description: Zero-based page index.
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+            default: 0
+            example: 0
+        - name: size
+          in: query
+          description: Number of items per page.
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 100
+            default: 20
+            example: 5
+      responses:
+        200:
+          description: Owner page found and returned.
+          headers:
+            ETag:
+              description: An ID for this version of the response.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OwnerPage'
+        304:
+          description: Not modified.
+          headers:
+            Etag:
+              description: An ID for this version of the response.
+              schema:
+                type: string
+        400:
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        500:
+          description: Server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
   /owners/{ownerId}:
     get:
       tags:
@@ -1936,6 +2003,51 @@ components:
               readOnly: true
           required:
             - pets
+    OwnerPage:
+      title: Owner page
+      description: A page of pet owners.
+      type: object
+      properties:
+        content:
+          title: Content
+          description: Pet owners in the requested page.
+          type: array
+          items:
+            $ref: '#/components/schemas/Owner'
+        page:
+          title: Page
+          description: Zero-based page index.
+          type: integer
+          format: int32
+          minimum: 0
+          example: 0
+        size:
+          title: Size
+          description: Requested page size.
+          type: integer
+          format: int32
+          minimum: 1
+          example: 5
+        totalElements:
+          title: Total elements
+          description: Total number of owners matching the request.
+          type: integer
+          format: int64
+          minimum: 0
+          example: 10
+        totalPages:
+          title: Total pages
+          description: Total number of pages matching the request.
+          type: integer
+          format: int32
+          minimum: 0
+          example: 2
+      required:
+        - content
+        - page
+        - size
+        - totalElements
+        - totalPages
     PetFields:
       title: Pet fields
       description: Editable fields of a pet.

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
@@ -22,6 +22,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.samples.petclinic.mapper.OwnerMapper;
 import org.springframework.samples.petclinic.mapper.PetMapper;
@@ -210,6 +213,27 @@ class OwnerRestControllerTests {
             .andExpect(jsonPath("$.[0].firstName").value("Betty"))
             .andExpect(jsonPath("$.[1].id").value(4))
             .andExpect(jsonPath("$.[1].firstName").value("Harold"));
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testGetOwnersPageSuccess() throws Exception {
+        var pageRequest = PageRequest.of(0, 2, Sort.by("id"));
+        var pageOwners = ownerMapper.toOwners(owners.subList(0, 2)).stream().toList();
+        given(this.clinicService.findOwners(null, pageRequest))
+            .willReturn(new PageImpl<>(pageOwners, pageRequest, owners.size()));
+        this.mockMvc.perform(get("/api/v2/owners?page=0&size=2")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json"))
+            .andExpect(jsonPath("$.content[0].id").value(1))
+            .andExpect(jsonPath("$.content[0].firstName").value("George"))
+            .andExpect(jsonPath("$.content[1].id").value(2))
+            .andExpect(jsonPath("$.content[1].firstName").value("Betty"))
+            .andExpect(jsonPath("$.page").value(0))
+            .andExpect(jsonPath("$.size").value(2))
+            .andExpect(jsonPath("$.totalElements").value(4))
+            .andExpect(jsonPath("$.totalPages").value(2));
     }
 
     @Test

--- a/src/test/java/org/springframework/samples/petclinic/service/clinicService/AbstractClinicServiceTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/clinicService/AbstractClinicServiceTests.java
@@ -17,6 +17,9 @@ package org.springframework.samples.petclinic.service.clinicService;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.samples.petclinic.model.*;
 import org.springframework.samples.petclinic.service.ClinicService;
 import org.springframework.samples.petclinic.util.EntityUtils;
@@ -340,6 +343,26 @@ abstract class AbstractClinicServiceTests {
         assertThat(owner1.getFirstName()).isEqualTo("George");
         Owner owner3 = EntityUtils.getById(owners, Owner.class, 3);
         assertThat(owner3.getFirstName()).isEqualTo("Eduardo");
+    }
+
+    @Test
+    void shouldFindOwnersPage(){
+        Page<Owner> owners = this.clinicService.findOwners(null, PageRequest.of(0, 3, Sort.by("id")));
+        assertThat(owners.getTotalElements()).isEqualTo(10);
+        assertThat(owners.getTotalPages()).isEqualTo(4);
+        assertThat(owners.getContent())
+            .extracting(Owner::getFirstName)
+            .containsExactly("George", "Betty", "Eduardo");
+    }
+
+    @Test
+    void shouldFindOwnersPageByLastName(){
+        Page<Owner> owners = this.clinicService.findOwners("Davis", PageRequest.of(0, 1, Sort.by("id")));
+        assertThat(owners.getTotalElements()).isEqualTo(2);
+        assertThat(owners.getTotalPages()).isEqualTo(2);
+        assertThat(owners.getContent())
+            .extracting(Owner::getFirstName)
+            .containsExactly("Betty");
     }
 
     @Test


### PR DESCRIPTION
This PR is the first in a series of PRs in order to implement and close #11.

## Summary
Adds a paginated v2 owners endpoint while keeping the existing `/api/owners` response unchanged for backward
compatibility. New endpoint:

```http
GET /api/v2/owners?page=0&size=20 
```
Also supports filtering by last name:

```http
GET /api/v2/owners?lastName=Davis&page=0&size=1
```
## Changes

  - Adds OwnerPage to the OpenAPI contract
  - Adds GET /v2/owners with page, size, and optional lastName
  - Implements pagination through the service and repository layers
  - Supports Spring Data JPA, JPA, and JDBC repository implementations
  - Adds controller and service tests for paginated owners
