### PR TITLE
Validate pet ownership in owner pet update endpoint

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
@@ -183,7 +183,7 @@ public class OwnerRestController implements OwnersApi, V2Api {
     public ResponseEntity<Void> updateOwnersPet(Integer ownerId, Integer petId, PetFieldsDto petFieldsDto) {
         Owner currentOwner = this.clinicService.findOwnerById(ownerId);
         if (currentOwner != null) {
-            Pet currentPet = this.clinicService.findPetById(petId);
+            Pet currentPet = currentOwner.getPet(petId);
             if (currentPet != null) {
                 currentPet.setBirthDate(petFieldsDto.getBirthDate());
                 currentPet.setName(petFieldsDto.getName());

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
@@ -182,17 +182,18 @@ public class OwnerRestController implements OwnersApi, V2Api {
     @Override
     public ResponseEntity<Void> updateOwnersPet(Integer ownerId, Integer petId, PetFieldsDto petFieldsDto) {
         Owner currentOwner = this.clinicService.findOwnerById(ownerId);
-        if (currentOwner != null) {
-            Pet currentPet = currentOwner.getPet(petId);
-            if (currentPet != null) {
-                currentPet.setBirthDate(petFieldsDto.getBirthDate());
-                currentPet.setName(petFieldsDto.getName());
-                currentPet.setType(petMapper.toPetType(petFieldsDto.getType()));
-                this.clinicService.savePet(currentPet);
-                return new ResponseEntity<>(HttpStatus.NO_CONTENT);
-            }
+        if(currentOwner==null){
+            return ResponseEntity.notFound().build();
         }
-        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        Pet currentPet = currentOwner.getPet(petId);
+        if(currentPet==null){
+            return ResponseEntity.notFound().build();
+        }
+        currentPet.setBirthDate(petFieldsDto.getBirthDate());
+        currentPet.setName(petFieldsDto.getName());
+        currentPet.setType(petMapper.toPetType(petFieldsDto.getType()));
+        clinicService.savePet(currentPet);
+        return ResponseEntity.noContent().build();
     }
 
     @PreAuthorize("hasRole(@roles.OWNER_ADMIN)")

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
@@ -591,20 +591,34 @@ class OwnerRestControllerTests {
     @WithMockUser(roles = "OWNER_ADMIN")
     void testUpdateOwnersPetSuccess() throws Exception {
         int ownerId = owners.get(0).getId();
-        int petId = pets.get(0).getId();
-        given(this.clinicService.findOwnerById(ownerId)).willReturn(ownerMapper.toOwner(owners.get(0)));
-        given(this.clinicService.findPetById(petId)).willReturn(petMapper.toPet(pets.get(0)));
-        PetDto updatedPetDto = pets.get(0);
+
+        // Owner 1 owns pet 1 in the test fixture
+        int petId = 1;
+
+        given(this.clinicService.findOwnerById(ownerId))
+            .willReturn(ownerMapper.toOwner(owners.get(0)));
+
+        PetDto updatedPetDto = new PetDto();
+        updatedPetDto.setId(petId);
         updatedPetDto.setName("Rex");
         updatedPetDto.setBirthDate(LocalDate.of(2020, 1, 15));
-        ObjectMapper mapper =  JsonMapper.builder()
+
+        PetTypeDto petType = new PetTypeDto();
+        petType.setId(2);
+        petType.setName("dog");
+        updatedPetDto.setType(petType);
+
+        ObjectMapper mapper = JsonMapper.builder()
             .defaultDateFormat(new SimpleDateFormat("dd/MM/yyyy"))
             .build();
+
         String updatedPetAsJSON = mapper.writeValueAsString(updatedPetDto);
-        this.mockMvc.perform(put("/api/owners/" + ownerId + "/pets/" + petId)
-                .content(updatedPetAsJSON)
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
+
+        this.mockMvc.perform(
+                put("/api/owners/" + ownerId + "/pets/" + petId)
+                    .content(updatedPetAsJSON)
+                    .accept(MediaType.APPLICATION_JSON_VALUE)
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isNoContent());
     }
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where `PUT /api/owners/{ownerId}/pets/{petId}` allowed updating a pet that did not belong to the specified owner.

## Problem

The endpoint verified that both the owner and pet existed, but it did not verify that the pet was actually owned by the provided owner. As a result, a request such as:

`PUT /api/owners/1/pets/12`

could successfully update pet `12` even though it belongs to owner `10`.

## Changes

* Added ownership validation before updating a pet.
* The endpoint now ensures that the specified pet belongs to the specified owner.
* Returns `404 Not Found` when the pet does not belong to the owner.

## Testing

Verified the following scenarios:

### Success Case

* `PUT /api/owners/10/pets/12`
* Pet belongs to owner `10`
* Response: `204 No Content`

### Failure Case

* `PUT /api/owners/1/pets/12`
* Pet belongs to owner `10`
* Response: `404 Not Found`

Fixes #310
