### PR TITLE
Encode password before persisting newly created users

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/service/UserServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/UserServiceImpl.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.samples.petclinic.model.User;
 import org.springframework.samples.petclinic.model.Role;
 import org.springframework.samples.petclinic.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +13,8 @@ public class UserServiceImpl implements UserService {
 
     @Autowired
     private UserRepository userRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     @Override
     @Transactional
@@ -30,6 +33,7 @@ public class UserServiceImpl implements UserService {
                 role.setUser(user);
             }
         }
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
 
         userRepository.save(user);
     }

--- a/src/test/java/org/springframework/samples/petclinic/service/userService/AbstractUserServiceTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/userService/AbstractUserServiceTests.java
@@ -6,6 +6,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.samples.petclinic.model.User;
 import org.springframework.samples.petclinic.service.UserService;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -15,6 +16,9 @@ public abstract class AbstractUserServiceTests {
     @Autowired
     private UserService userService;
 
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
     @BeforeEach
     public void init() {
         MockitoAnnotations.openMocks(this);
@@ -22,14 +26,16 @@ public abstract class AbstractUserServiceTests {
 
     @Test
     public void shouldAddUser() throws Exception {
+        String rawPassword = "password";
         User user = new User();
         user.setUsername("username");
-        user.setPassword("password");
+        user.setPassword(rawPassword);
         user.setEnabled(true);
         user.addRole("OWNER_ADMIN");
 
         userService.saveUser(user);
         assertThat(user.getRoles().parallelStream().allMatch(role -> role.getName().startsWith("ROLE_")), is(true));
         assertThat(user.getRoles().parallelStream().allMatch(role -> role.getUser() != null), is(true));
+        assert(passwordEncoder.matches(rawPassword, user.getPassword()));
     }
 }


### PR DESCRIPTION
The POST /users endpoint currently stores passwords in plain text, while the application authenticates users using BCryptPasswordEncoder.

As a result, users created via the API cannot authenticate using HTTP Basic authentication.

This change encodes the password before persisting the user, making user creation consistent with the configured PasswordEncoder.