### PR TITLE
Fix H2 console support with Spring Boot 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,10 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-h2console</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
             <scope>runtime</scope>


### PR DESCRIPTION
## Description

Fixed the H2 console not being available when running the project with Spring Boot 4.1.0.

## Problem

The H2 console was not accessible at:

`/petclinic/h2-console`

The application also did not log:

`H2 console available at '/h2-console'`

This happened because Spring Boot 4 moved H2 console auto-configuration into the dedicated `spring-boot-h2console` module.

## Solution

Added the `spring-boot-h2console` dependency to `pom.xml`.

## Testing

- Ran `.\mvnw.cmd clean test`
- Tests run: 237
- Failures: 0
- Errors: 0
- Skipped: 0
- Verified the application starts with the `h2,spring-data-jpa` profiles.
- Verified the log contains:
  `H2 console available at '/h2-console'`
- Verified the H2 console is accessible at `/petclinic/h2-console`.

Fixes #347